### PR TITLE
feat: token 발행 후 사용자 데이터 접근

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,7 +1,7 @@
 import HttpClient from './httpClient';
 
 // TODO: API 서버 배포 후 설정 필요
-const API_URL = 'https://8d84-118-219-132-159.ngrok-free.app';
+const API_URL = '';
 
 export const api = new HttpClient({
   baseURL: API_URL,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,7 +1,7 @@
 import HttpClient from './httpClient';
 
 // TODO: API 서버 배포 후 설정 필요
-const API_URL = '';
+const API_URL = 'https://8d84-118-219-132-159.ngrok-free.app';
 
 export const api = new HttpClient({
   baseURL: API_URL,

--- a/src/app/login/oauth2/code/google/page.tsx
+++ b/src/app/login/oauth2/code/google/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { AxiosResponse } from 'axios';
 
 import { api } from '@/apis';
 
@@ -12,7 +13,7 @@ export default function GoogleLogin() {
 
   useEffect(() => {
     try {
-      api.get('/my').then((response) => {
+      api.get('/my').then((response: AxiosResponse) => {
         setEmail(response.data.email);
         console.log(response.data.email);
       });

--- a/src/app/login/oauth2/code/google/page.tsx
+++ b/src/app/login/oauth2/code/google/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+import { api } from '@/apis';
+
+export default function GoogleLogin() {
+  const [email, setEmail] = useState<string>('');
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  // TODO: query string으로 JWT Token을 받아서 쿠키에 저장하는 로직이 필요합니다.
+
+  useEffect(() => {
+    try {
+      api.get('/my').then((response) => {
+        setEmail(response.data.email);
+        console.log(response.data.email);
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  }, [token]);
+
+  return <div>current user email: {email}</div>;
+}

--- a/src/app/login/oauth2/code/google/page.tsx
+++ b/src/app/login/oauth2/code/google/page.tsx
@@ -5,7 +5,7 @@ import { AxiosResponse } from 'axios';
 
 import { api } from '@/apis';
 
-export default function GoogleLogin() {
+const GoogleLogin = () => {
   const [email, setEmail] = useState<string>('');
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
@@ -23,4 +23,6 @@ export default function GoogleLogin() {
   }, [token]);
 
   return <div>current user email: {email}</div>;
-}
+};
+
+export default GoogleLogin;

--- a/src/app/login/oauth2/code/google/page.tsx
+++ b/src/app/login/oauth2/code/google/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { AxiosResponse } from 'axios';
+import type { AxiosResponse } from 'axios';
 
 import { api } from '@/apis';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,15 @@
+'use client';
+
 export default function Home() {
-  return <>home</>;
+  const onClickButton = () => {
+    window.location.href = 'https://8d84-118-219-132-159.ngrok-free.app/oauth2/authorization/google';
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={onClickButton}>
+        google로 로그인
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 서버가 발급한 JWT token을 발급 받음
- 발급 받은 토큰을 헤더에 담아 사용자 데이터 요청

## 🎉 어떻게 해결했나요?
- 서버에서 query string으로 JWT token을 발행
  - 서버에서 구글로부터 access token을 발급 받은 후 새롭게 JWT token을 발행하고 redirect를 통해 token을 전달해야해서 현재 query string을 이용한 전달 방법 밖에 찾자 못했습니다. 혹시 다른 방법을 아신다면 코멘트 주세요!
  - 이후 token과 사용자 정보를 저장하는 로직을 추가해야 합니다! 

### 📚 Attachment (Option)
- 이전 PR 닫고 새로 브랜치 따서 다시 올렸습니다~~

