### PR TITLE
chore: stories 파일이 있을 경우에만 workflow 실행되도록

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,8 +4,12 @@ name: 'Chromatic Deployment'
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '**.stories.tsx'
   push:
     branches: [main]
+    paths:
+      - '**.stories.tsx'
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- stories 파일이 없을 경우에도 Chromatic workflow가 실행 → 큰 의미는 없지만 결과적으로 ❌(실패는 아닌데 실패로..)

## 🎉 어떻게 해결했나요?
- paths로 `**.stories.tsx`가 존재할 경우에만 workflow가 실행되도록 설정했습니다.

### 📚 Attachment (Option)
(해당 PR 하단) 잘 적용된 거 확인했슴다 🕺

![image](https://github.com/depromeet/amazing3-fe/assets/112946860/5e7df3f2-99fa-4ed4-a6b5-33f9e9b55fb6)

