### PR TITLE
feat: ContentWrapper 컴포넌트 및 Story 추가

### DIFF
--- a/src/components/molecules/contentWrapper/ContentWrapper.stories.tsx
+++ b/src/components/molecules/contentWrapper/ContentWrapper.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ContentWrapper } from './ContentWrapper';
+
+const meta: Meta<typeof ContentWrapper> = {
+  title: 'components/molecules/contentWrapper',
+  component: ContentWrapper,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ContentWrapper>;
+
+export const Basic: Story = {
+  args: {
+    title: (
+      <>
+        반가워요, 닉네임님! <br />
+        생년월일을 입력해 주세요.
+      </>
+    ),
+    children: (
+      <div className="mt-[20px] w-[300px] h-[300px] bg-purple-10 rounded-md p-[15px]">
+        children에는 자유롭게 들어갈 수 있어요
+      </div>
+    ),
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    ...Basic.args,
+    description: 'beta에서는 생년월일을 수정할 수 없어요.',
+  },
+};

--- a/src/components/molecules/contentWrapper/ContentWrapper.tsx
+++ b/src/components/molecules/contentWrapper/ContentWrapper.tsx
@@ -1,0 +1,24 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { Typography } from '@/components';
+
+interface ContentWrapperProps {
+  title: string | ReactNode;
+  description?: string;
+}
+
+export const ContentWrapper = ({ title, description, children }: PropsWithChildren<ContentWrapperProps>) => {
+  return (
+    <section>
+      <Typography type="heading1" className="text-blue-50">
+        {title}
+      </Typography>
+      {description && (
+        <Typography type="title4" className="mt-[8px] text-gray-40">
+          {description}
+        </Typography>
+      )}
+      <div>{children}</div>
+    </section>
+  );
+};

--- a/src/components/molecules/contentWrapper/index.ts
+++ b/src/components/molecules/contentWrapper/index.ts
@@ -1,0 +1,1 @@
+export { ContentWrapper } from './ContentWrapper';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,1 +1,2 @@
+export { ContentWrapper } from './contentWrapper';
 export { LimitedLengthInput } from './limitedLengthInput';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 온보딩 및 홈화면에서 자주 사용되는 레이아웃 존재
<img width="200" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/97c4efa0-1412-4799-b29f-4c1d046156e8">


## 🎉 어떻게 해결했나요?
- title, description(optional), children으로 구성하여 모듈화했어요.
- MVP 단계에서는 모든 title의 컬러가 동일하여 우선은 기본으로 `blue-50`으로 지정해 두었어요.

### 📚 Attachment (Option)
- 얼른 반영해서 준영넴과 같이 사용하면 좋을 거 같아서 빨리 PR 날렸슴다 🕺

