### PR TITLE
chore: atom/Button에 디자인 시스템 적용

### DIFF
--- a/src/components/atoms/bottomSheet/BottomSheet.stories.tsx
+++ b/src/components/atoms/bottomSheet/BottomSheet.stories.tsx
@@ -27,11 +27,7 @@ export const BasicBottomSheet: Story = {
   args: {
     open: true,
     HeaderComponent: <p className="text-xl font-bold flex items-center justify-between mb-2">문답 가이드</p>,
-    FooterComponent: (
-      <Button intent="primary" size="xl">
-        적용
-      </Button>
-    ),
+    FooterComponent: <Button>적용</Button>,
     children: (
       <ul>
         {contents.map((content, index) => (

--- a/src/components/atoms/button/Button.stories.tsx
+++ b/src/components/atoms/button/Button.stories.tsx
@@ -15,9 +15,13 @@ const meta: Meta<typeof Button> = {
       control: 'inline-radio',
       options: ['none', 'sm', 'md', 'lg', 'xl'],
     },
-    size: {
+    width: {
       control: 'inline-radio',
-      options: ['lg'],
+      options: ['full'],
+    },
+    height: {
+      control: 'inline-radio',
+      options: ['h60', 'h40'],
     },
     disabled: {
       control: 'boolean',
@@ -57,10 +61,10 @@ export const Issue: Story = {
   },
 };
 
-export const CustomSize: Story = {
+export const Height44: Story = {
   args: {
     ...Basic.args,
-    className: 'w-[400px] h-[100px]',
+    height: 'h44',
   },
 };
 

--- a/src/components/atoms/button/Button.stories.tsx
+++ b/src/components/atoms/button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import Image from 'next/image';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './Button';
@@ -7,22 +7,20 @@ const meta: Meta<typeof Button> = {
   title: 'components/atoms/button',
   component: Button,
   argTypes: {
-    intent: {
-      control: {
-        type: 'select',
-        options: ['primary', 'secondary', 'success', 'danger', 'warning'],
-      },
+    variant: {
+      control: 'inline-radio',
+      options: ['heavy', 'blue', 'tertiary', 'issue'],
+    },
+    rounded: {
+      control: 'inline-radio',
+      options: ['none', 'sm', 'md', 'lg', 'xl'],
     },
     size: {
-      control: {
-        type: 'select',
-        options: ['xl', 'lg', 'md', 'sm', 'xs'],
-      },
+      control: 'inline-radio',
+      options: ['lg'],
     },
     disabled: {
-      control: {
-        type: 'boolean',
-      },
+      control: 'boolean',
     },
     onClick: { action: 'clicked' },
   },
@@ -32,22 +30,51 @@ export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const BasicButton: Story = {
+export const Basic: Story = {
   args: {
-    intent: 'primary',
-    size: 'xl',
-    children: 'Basic Button',
+    children: 'Button',
+  },
+};
+
+export const Blue: Story = {
+  args: {
+    ...Basic.args,
+    variant: 'blue',
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    ...Basic.args,
+    variant: 'tertiary',
+  },
+};
+
+export const Issue: Story = {
+  args: {
+    ...Basic.args,
+    variant: 'issue',
+  },
+};
+
+export const CustomSize: Story = {
+  args: {
+    ...Basic.args,
+    className: 'w-[400px] h-[100px]',
   },
 };
 
 export const WithIcon: Story = {
   args: {
-    intent: 'primary',
-    size: 'xl',
     children: (
       <>
-        <MagnifyingGlassIcon className="mr-1 h-6 w-6" />
-        Button with Icon
+        <Image
+          src="https://github.com/depromeet/amazing3-fe/assets/112946860/33330865-9656-4184-94a7-53a46e7d0150"
+          width="15"
+          height="15"
+          alt="icon"
+        />
+        Button
       </>
     ),
   },

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -21,14 +21,19 @@ const buttonVariants = cva(
         lg: 'rounded-lg',
         xl: 'rounded-xl',
       },
-      size: {
-        lg: 'w-[342px] h-[60px]',
+      width: {
+        full: 'w-full',
+      },
+      height: {
+        h60: 'h-[60px]',
+        h44: 'h-[44px]',
       },
     },
     defaultVariants: {
       variant: 'heavy',
       rounded: 'lg',
-      size: 'lg',
+      width: 'full',
+      height: 'h60',
     },
   },
 );
@@ -36,8 +41,8 @@ const buttonVariants = cva(
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {}
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, rounded, size, ...props }, ref) => {
-    return <button className={buttonVariants({ variant, rounded, size, className })} ref={ref} {...props} />;
+  ({ className, variant, rounded, width, height, ...props }, ref) => {
+    return <button className={buttonVariants({ variant, rounded, width, height, className })} ref={ref} {...props} />;
   },
 );
 Button.displayName = 'Button';

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -5,35 +5,39 @@ import { cva, type VariantProps } from 'class-variance-authority';
  * TODO: 디자인 시스템에 맞게 수정
  */
 const buttonVariants = cva(
-  'inline-flex h-10 items-center justify-center word-break:keep-all text-white disabled:pointer-events-nonedisabled:pointer-events-none disabled:opacity-50',
+  'inline-flex gap-[6px] h-10 items-center justify-center word-break:keep-all disabled:pointer-events-nonedisabled:pointer-events-none disabled:opacity-30 transition-colors duration-200 font-semibold',
   {
     variants: {
-      intent: {
-        primary: 'bg-blue-700 hover:bg-blue-800 focus:bg-blue-800 disabled:bg-gray-40',
-        secondary: 'bg-black hover:bg-gray-800 focus:bg-gray-800 disabled:bg-gray-40',
-        label: 'font-semibold text-black underline-offset-4 disabled:text-gray-40',
-        success: 'bg-green-700 hover:bg-green-800 focus:bg-green-800 disabled:bg-gray-40',
-        danger: 'bg-red-700 hover:bg-red-800 focus:bg-red-800 disabled:bg-gray-40',
+      variant: {
+        heavy: 'bg-gray-60 text-white hover:bg-gray-70',
+        blue: 'bg-blue-10 text-blue-30',
+        tertiary: 'bg-gray-20 text-gray-40',
+        issue: 'bg-red-20 text-red-50',
+      },
+      rounded: {
+        none: 'rounded-none',
+        sm: 'rounded-sm',
+        md: 'rounded-md',
+        lg: 'rounded-lg',
+        xl: 'rounded-xl',
       },
       size: {
-        xl: 'w-full rounded-lg px-[2.5rem] py-3',
-        lg: 'w-[16.25rem] rounded-md px-[2.5rem] py-3',
-        md: 'w-[12.5rem] rounded-md px-[2.5rem] py-3',
-        sm: 'w-[10.25rem] rounded-md px-[2.5rem] py-3',
-        xs: 'w-[5px] rounded-lg px-[2.5rem] py-3',
-        none: 'rounded-lg px-[2.5rem] py-3',
+        lg: 'w-[342px] h-[60px]',
       },
     },
     defaultVariants: {
-      intent: 'primary',
-      size: 'xl',
+      variant: 'heavy',
+      rounded: 'lg',
+      size: 'lg',
     },
   },
 );
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {}
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ className, intent, size, ...props }, ref) => {
-  return <button className={buttonVariants({ intent, size, className })} ref={ref} {...props} />;
-});
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, rounded, size, ...props }, ref) => {
+    return <button className={buttonVariants({ variant, rounded, size, className })} ref={ref} {...props} />;
+  },
+);
 Button.displayName = 'Button';

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
  * TODO: 디자인 시스템에 맞게 수정
  */
 const buttonVariants = cva(
-  'inline-flex gap-[6px] h-10 items-center justify-center word-break:keep-all disabled:pointer-events-nonedisabled:pointer-events-none disabled:opacity-30 transition-colors duration-200 font-semibold',
+  'inline-flex gap-[6px] items-center justify-center word-break:keep-all disabled:pointer-events-nonedisabled:pointer-events-none disabled:opacity-30 transition-colors duration-200 font-semibold',
   {
     variants: {
       variant: {

--- a/src/features/auth/components/GoogleLoginButton.tsx
+++ b/src/features/auth/components/GoogleLoginButton.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 
 import GoogleIcon from '@/assets/icons/google-icon.svg';
-import { Button } from '@/components/atoms/button';
+import { Button } from '@/components';
 
 export const GoogleLoginButton = () => {
   /**
@@ -13,8 +13,8 @@ export const GoogleLoginButton = () => {
 
   return (
     <Link href={oauthRequestUrl}>
-      <Button className="pl-2xs pr-2xs" size="lg">
-        <GoogleIcon width={24} />
+      <Button className="pl-2xs pr-2xs">
+        <GoogleIcon width={24} alt="google-logo" />
         Google 로그인
       </Button>
     </Link>

--- a/src/features/goal/components/new/GoalForm.tsx
+++ b/src/features/goal/components/new/GoalForm.tsx
@@ -27,12 +27,10 @@ export const GoalForm = () => {
             return <GoalGuideBottomSheet open={isOpen} onClose={close} setValue={setValue} />;
           });
         }}
-        intent="primary"
-        size="sm"
       >
         목표 추천
       </Button>
-      <Button onClick={handleClickNextButton} disabled={!watch('title')} intent="primary" size="xl">
+      <Button onClick={handleClickNextButton} disabled={!watch('title')}>
         다음
       </Button>
     </div>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 기존에 모듈화 되어있던 Button 컴포넌트에 디자인 시스템 적용이 필요했습니다.

## 🎉 어떻게 해결했나요?
- [Figma 디자인 시스템](https://www.figma.com/file/hREAodauJnxgE6SBuF0ZYR/UI%2FDesgin-system?type=design&node-id=31-3667&mode=design&t=VcdFoMhuopQqbcUd-11) 참고하여 최대한 반영했습니다.
- variant: heavy, blue, tertiary, issue 입니다.
- icon이랑 함께 사용할 수 있도록 적용했습니다.
- 필요시 className으로 마음껏 스타일 변경 가능합니다 ^_^

### 📚 Attachment (Option)
- `blue`, `tertiary`, `issue`의 경우 hover 되었을 때 color를 10씩 올리려고 했으나 UX에 좋지 못한 것 같아서 우선 제외했습니다.
- 그래서 위 버튼들은 아직 많이 사용되지 않는 것 같아서, 추후에 디자이너분들께 hover시 bgColor와 textColor를 명시해 달라고 부탁드리면 좋을 거 같습니다.
- 디자인 시스템에서와 실제 UI에서의 disabled 스타일이 다른데... 우선 기존 Button의 disabled 스타일링으로 유지해놓았습니다(그랬더니 실제 UI에서 사용되는 스타일과 비슷한 거 같아요)
<img width="500" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/d5375015-d847-482b-9c6d-219a3d58d2f0">

### 아무튼 최대한 디자인 시스템을 반영했으나, 추후에 수정될 가능성이 있을 거 같습니다 🤔
### 피드백 환영합니다.. 🙏