### PR TITLE
chore: 서버에 위치한 이미지 읽을 때 필요한 설정 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,16 @@ const nextConfig = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: `${process.env.NEXT_PUBLIC_REMOTE_HOST}`,
+        port: '',
+        pathname: '/images/**',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 홈 서버에 위치한  이미지를 읽기 위한 설정 추가

## 🎉 어떻게 해결했나요?
- next.config.js 설정 추가

### 📚 Attachment (Option)
- 설정 적용 후 출력 결과
![스크린샷 2023-12-20 224626](https://github.com/depromeet/amazing3-fe/assets/34956359/d233b9a8-d50e-46f3-976f-7ddced4a0a4e)
사용 방법은 `import Image from 'next/image';` 를 사용하여 `src` 값에 서버의 asset url 그대로 넣어주시면 반영됩니다~


