### PR TITLE
feat: 목표 추가 로직에 해당하는 페이지들의 header 구현 및 적용

### DIFF
--- a/src/features/goal/components/new/DateForm.tsx
+++ b/src/features/goal/components/new/DateForm.tsx
@@ -7,7 +7,10 @@ import { Button, Span, Typography } from '@/components';
 import { MAX_DATE_LENGTH_UNTIL_MONTH } from '@/constants';
 import type { GoalFormValues } from '@/features/goal/types';
 
+import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+
 import { DateInput } from './DateInput';
+import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 export const DateForm = () => {
@@ -18,7 +21,7 @@ export const DateForm = () => {
 
   return (
     <FormLayout
-      header={<Typography className="text-gray-50 font-insungit text-center">header</Typography>}
+      header={<FormHeader formNumber={NEW_GOAL_FORM_ORDERS.date} />}
       comment={
         <Typography type="title3" className="text-gray-50 font-insungit text-center">
           {title} <br /> <Span type="blue50">언제</Span>까지 이루고 싶어?

--- a/src/features/goal/components/new/FormHeader.tsx
+++ b/src/features/goal/components/new/FormHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
@@ -17,8 +19,6 @@ const FormHeader = ({ formNumber }: FormHeaderProps) => {
   const handleClickBackButton = () => {
     router.back();
   };
-
-  console.log(currentProgress);
 
   return (
     <div className="flex justify-between items-center">

--- a/src/features/goal/components/new/FormHeader.tsx
+++ b/src/features/goal/components/new/FormHeader.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import BackIcon from '@/assets/icons/goal/back-icon.svg';
+import CloseIcon from '@/assets/icons/goal/close-icon.svg';
+
+import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+
+interface FormHeaderProps {
+  formNumber: number;
+}
+
+const FormHeader = ({ formNumber }: FormHeaderProps) => {
+  const totalPages = Object.keys(NEW_GOAL_FORM_ORDERS).length;
+  const router = useRouter();
+  const handleClickBackButton = () => {
+    router.back();
+  };
+
+  return (
+    <div className="flex justify-between items-center">
+      <button onClick={handleClickBackButton}>
+        <BackIcon />
+      </button>
+      <div className="w-[30%]">
+        <div className="relative w-[100%] h-[6px] rounded-lg bg-white">
+          <div
+            className={`absolute top-0 left-0 w-[${(formNumber / totalPages) * 100}%] h-[6px] rounded-lg bg-blue-30`}
+          />
+        </div>
+      </div>
+      <Link href={{ pathname: '/home' }}>
+        <CloseIcon />
+      </Link>
+    </div>
+  );
+};
+
+export default FormHeader;

--- a/src/features/goal/components/new/FormHeader.tsx
+++ b/src/features/goal/components/new/FormHeader.tsx
@@ -27,7 +27,10 @@ const FormHeader = ({ formNumber }: FormHeaderProps) => {
       </button>
       <div className="w-[30%]">
         <div className="relative w-[100%] h-[6px] rounded-lg bg-white">
-          <div className={`absolute top-0 left-0 w-[${currentProgress}%] h-[6px] rounded-lg bg-blue-30 z-[1]`} />
+          <div
+            className="absolute top-0 left-0 h-[6px] rounded-lg bg-blue-30 z-[1]"
+            style={{ width: `${currentProgress}%` }}
+          />
         </div>
       </div>
       <Link href={{ pathname: '/home' }}>

--- a/src/features/goal/components/new/FormHeader.tsx
+++ b/src/features/goal/components/new/FormHeader.tsx
@@ -4,19 +4,21 @@ import { useRouter } from 'next/navigation';
 import BackIcon from '@/assets/icons/goal/back-icon.svg';
 import CloseIcon from '@/assets/icons/goal/close-icon.svg';
 
-import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+import { NEW_GOAL_FORM_ORDERS_LENGTH } from '../../constants';
 
 interface FormHeaderProps {
   formNumber: number;
 }
 
 const FormHeader = ({ formNumber }: FormHeaderProps) => {
-  const totalPages = Object.keys(NEW_GOAL_FORM_ORDERS).length;
+  const totalPages = NEW_GOAL_FORM_ORDERS_LENGTH;
   const currentProgress = (formNumber / totalPages) * 100;
   const router = useRouter();
   const handleClickBackButton = () => {
     router.back();
   };
+
+  console.log(currentProgress);
 
   return (
     <div className="flex justify-between items-center">

--- a/src/features/goal/components/new/FormHeader.tsx
+++ b/src/features/goal/components/new/FormHeader.tsx
@@ -12,6 +12,7 @@ interface FormHeaderProps {
 
 const FormHeader = ({ formNumber }: FormHeaderProps) => {
   const totalPages = Object.keys(NEW_GOAL_FORM_ORDERS).length;
+  const currentProgress = (formNumber / totalPages) * 100;
   const router = useRouter();
   const handleClickBackButton = () => {
     router.back();
@@ -24,9 +25,7 @@ const FormHeader = ({ formNumber }: FormHeaderProps) => {
       </button>
       <div className="w-[30%]">
         <div className="relative w-[100%] h-[6px] rounded-lg bg-white">
-          <div
-            className={`absolute top-0 left-0 w-[${(formNumber / totalPages) * 100}%] h-[6px] rounded-lg bg-blue-30`}
-          />
+          <div className={`absolute top-0 left-0 w-[${currentProgress}%] h-[6px] rounded-lg bg-blue-30 z-[1]`} />
         </div>
       </div>
       <Link href={{ pathname: '/home' }}>

--- a/src/features/goal/components/new/FormLayout.tsx
+++ b/src/features/goal/components/new/FormLayout.tsx
@@ -9,12 +9,10 @@ interface FormLayoutProps {
 
 const FormLayout = ({ header, comment, body, footer }: PropsWithChildren<FormLayoutProps>) => {
   return (
-    <div className="px-xs h-full flex flex-col">
+    <div className="pt-5xs px-xs h-full flex flex-col">
       <div className="h-1/2 flex flex-col">
-        <div className="h-[40%] flex flex-col justify-evenly">
-          {header}
-          {comment}
-        </div>
+        {header}
+        <div className="h-[40%] flex flex-col justify-evenly">{comment}</div>
       </div>
       <div className="h-1/2 flex flex-col">{body}</div>
       {footer}

--- a/src/features/goal/components/new/GoalForm.tsx
+++ b/src/features/goal/components/new/GoalForm.tsx
@@ -7,6 +7,9 @@ import { useOverlay } from '@toss/use-overlay';
 import { Button, Span, Typography } from '@/components/atoms';
 import type { GoalFormValues } from '@/features/goal/types';
 
+import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+
+import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 import GoalGuideBottomSheet from './GoalGuideBottomSheet';
 import { TextInput } from './TextInput';
@@ -19,7 +22,7 @@ export const GoalForm = () => {
 
   return (
     <FormLayout
-      header={<Typography className="text-gray-50 font-insungit text-center">header</Typography>}
+      header={<FormHeader formNumber={NEW_GOAL_FORM_ORDERS.goal} />}
       comment={
         <Typography type="title3" className="text-gray-50 font-insungit text-center">
           꼭 이루고 싶은

--- a/src/features/goal/components/new/MoreForm.tsx
+++ b/src/features/goal/components/new/MoreForm.tsx
@@ -7,6 +7,9 @@ import { Button, Typography } from '@/components';
 import { MAX_TEXTAREA_LENGTH } from '@/constants';
 import type { GoalFormValues } from '@/features/goal/types';
 
+import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+
+import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 import { TextInput } from './TextInput';
 
@@ -19,7 +22,7 @@ export const MoreForm = () => {
 
   return (
     <FormLayout
-      header={<Typography className="text-gray-50 font-insungit text-center">header</Typography>}
+      header={<FormHeader formNumber={NEW_GOAL_FORM_ORDERS.more} />}
       comment={
         <Typography type="title3" className="text-gray-50 font-insungit text-center">
           마지막으로 더 작성하고 싶은 것이 <br />

--- a/src/features/goal/components/new/StickerForm.tsx
+++ b/src/features/goal/components/new/StickerForm.tsx
@@ -6,6 +6,9 @@ import Link from 'next/link';
 import { Button, Span, Typography } from '@/components';
 import type { GoalFormValues } from '@/features/goal/types';
 
+import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+
+import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 export const StickerForm = () => {
@@ -15,7 +18,7 @@ export const StickerForm = () => {
 
   return (
     <FormLayout
-      header={<Typography className="text-gray-50 font-insungit text-center">header</Typography>}
+      header={<FormHeader formNumber={NEW_GOAL_FORM_ORDERS.sticker} />}
       comment={
         <Typography type="title3" className="text-gray-50 font-insungit text-center">
           목표와 관련된 <Span type="blue50">스티커</Span>도

--- a/src/features/goal/components/new/TagForm.tsx
+++ b/src/features/goal/components/new/TagForm.tsx
@@ -6,6 +6,9 @@ import Link from 'next/link';
 import { Button, Span, Typography } from '@/components';
 import type { GoalFormValues } from '@/features/goal/types';
 
+import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+
+import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 const MOCK_TAGS = [
@@ -22,7 +25,7 @@ export const TagForm = () => {
 
   return (
     <FormLayout
-      header={<Typography className="text-gray-50 font-insungit text-center">header</Typography>}
+      header={<FormHeader formNumber={NEW_GOAL_FORM_ORDERS.tag} />}
       comment={
         <Typography type="title3" className="text-gray-50 font-insungit text-center">
           목표와 관련된 <Span type="blue50">태그</Span> 한 가지를

--- a/src/features/goal/constants/goal.ts
+++ b/src/features/goal/constants/goal.ts
@@ -1,0 +1,7 @@
+export const NEW_GOAL_FORM_ORDERS = {
+  goal: 1,
+  date: 2,
+  tag: 3,
+  sticker: 4,
+  more: 5,
+};

--- a/src/features/goal/constants/goal.ts
+++ b/src/features/goal/constants/goal.ts
@@ -1,3 +1,4 @@
+export const NEW_GOAL_FORM_ORDERS_LENGTH = 5;
 export const NEW_GOAL_FORM_ORDERS = {
   goal: 1,
   date: 2,

--- a/src/features/goal/constants/index.ts
+++ b/src/features/goal/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './goal';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 목표 추가 로직에 해당하는 페이지들의 미구현된 header를 구현하고 적용

## 🎉 어떻게 해결했나요?
- 홍석님이 목표 저장 페이지에 사용한 icon 재사용
- 프로그레스바는 두개의 div를 absolute를 이용하여 겹쳐 구현

### 📚 Attachment (Option)
- N/A

