### PR TITLE
feat: goal 추가 화면의 sticker 추가 기능 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,9 @@
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true,
-    "source.addMissingImports": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit",
+    "source.addMissingImports": "explicit"
   },
   "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,9 @@
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.fixAll.stylelint": "explicit",
-    "source.addMissingImports": "explicit"
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true,
+    "source.addMissingImports": true
   },
   "editor.formatOnSave": true
 }

--- a/src/app/goal/new/layout.tsx
+++ b/src/app/goal/new/layout.tsx
@@ -24,9 +24,6 @@ const Layout = ({ children }: PropsWithChildren) => {
         <div className="absolute top-[40%] w-full h-[60%] overflow-hidden">
           <Wave className="absolute w-full" />
         </div>
-        {/* <div className="overflow-hidden top-[40%] relative">
-          <Wave className="absolute w-full h-full" />
-        </div> */}
         <div className="absolute top-0 left-0 w-full h-[calc(100vh-24px)]">{children}</div>
       </div>
     </CreateGoalFormProvider>

--- a/src/app/goal/new/layout.tsx
+++ b/src/app/goal/new/layout.tsx
@@ -21,7 +21,12 @@ const Layout = ({ children }: PropsWithChildren) => {
           alt="BandiBoodi Character"
           priority
         />
-        <Wave className="absolute top-[40%] w-full" />
+        <div className="absolute top-[40%] w-full h-[60%] overflow-hidden">
+          <Wave className="absolute w-full" />
+        </div>
+        {/* <div className="overflow-hidden top-[40%] relative">
+          <Wave className="absolute w-full h-full" />
+        </div> */}
         <div className="absolute top-0 left-0 w-full h-[calc(100vh-24px)]">{children}</div>
       </div>
     </CreateGoalFormProvider>

--- a/src/features/goal/components/new/GoalForm.tsx
+++ b/src/features/goal/components/new/GoalForm.tsx
@@ -43,7 +43,7 @@ export const GoalForm = () => {
             <Typography type="caption1" className="text-gray-40">
               목표 세우기, 너무 막연하다면?
             </Typography>
-            <div className="w-[180px]">
+            <div className="w-[200px]">
               <Button
                 className="py-3xs px-xs text-sm"
                 variant="blue"

--- a/src/features/goal/components/new/StickerForm.tsx
+++ b/src/features/goal/components/new/StickerForm.tsx
@@ -57,7 +57,7 @@ export const StickerForm = () => {
       }
       footer={
         <Link href="/goal/new/more" className="z-[1]">
-          <Button>다음</Button>
+          <Button disabled={!selectedSticker}>다음</Button>
         </Link>
       }
     />

--- a/src/features/goal/components/new/StickerForm.tsx
+++ b/src/features/goal/components/new/StickerForm.tsx
@@ -41,13 +41,9 @@ export const StickerForm = () => {
               <div {...register('sticker')} className="grid grid-cols-3 gap-3xs">
                 {stickerData?.map(({ id, name, url }) => (
                   <button key={id} className="flex flex-col items-center" onClick={() => handleClickSticker(id)}>
-                    <Image
-                      src={url}
-                      alt={name}
-                      width={150}
-                      height={150}
-                      className={`rounded-lg ${selectedSticker === id && 'bg-blue-10'}`}
-                    />
+                    <div className={`p-5xs rounded-lg ${selectedSticker === id && 'bg-blue-10'}`}>
+                      <Image src={url} alt={name} width={150} height={150} />
+                    </div>
                   </button>
                 ))}
               </div>

--- a/src/features/goal/components/new/StickerForm.tsx
+++ b/src/features/goal/components/new/StickerForm.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import Image from 'next/image';
 import Link from 'next/link';
 
 import { Button, Span, Typography } from '@/components';
 import type { GoalFormValues } from '@/features/goal/types';
+import { useGetStickers } from '@/hooks/reactQuery/sticker';
 
 import { NEW_GOAL_FORM_ORDERS } from '../../constants';
 
@@ -12,9 +15,14 @@ import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 export const StickerForm = () => {
-  const { register } = useFormContext<GoalFormValues>();
+  const { register, setValue } = useFormContext<GoalFormValues>();
+  const [selectedSticker, setSelectedSticker] = useState<number | null>(null);
+  const { data: stickerData } = useGetStickers();
 
-  const handleClickNextButton = () => {};
+  const handleClickSticker = (id: number) => {
+    setSelectedSticker(id);
+    setValue('sticker', id);
+  };
 
   return (
     <FormLayout
@@ -26,10 +34,30 @@ export const StickerForm = () => {
           선택해줘.
         </Typography>
       }
-      body={<input {...register('sticker')} type="text" placeholder="스티커" />}
+      body={
+        <div className="absolute h-[50%] inset-x-0 w-full pt-md">
+          <div className="absolute w-full h-full bg-white rounded-lg">
+            <div className="h-[calc(100%-90px)] my-2xs px-2xs overflow-auto">
+              <div {...register('sticker')} className="grid grid-cols-3 gap-3xs">
+                {stickerData?.map(({ id, name, url }) => (
+                  <button key={id} className="flex flex-col items-center" onClick={() => handleClickSticker(id)}>
+                    <Image
+                      src={url}
+                      alt={name}
+                      width={150}
+                      height={150}
+                      className={`rounded-lg ${selectedSticker === id && 'bg-blue-10'}`}
+                    />
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      }
       footer={
-        <Link href="/goal/new/more">
-          <Button onClick={handleClickNextButton}>다음</Button>
+        <Link href="/goal/new/more" className="z-[1]">
+          <Button>다음</Button>
         </Link>
       }
     />

--- a/src/features/goal/components/new/TagForm.tsx
+++ b/src/features/goal/components/new/TagForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import Link from 'next/link';
 
@@ -13,11 +14,12 @@ import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 export const TagForm = () => {
-  const { register, watch, setValue } = useFormContext<GoalFormValues>();
-  const selectedTag = watch('tag');
+  const { register, setValue } = useFormContext<GoalFormValues>();
+  const [selectedTag, setSelectedTag] = useState<number | null>(null);
   const { data: tagsData } = useGetTags();
 
   const handleClickTag = (id: number) => {
+    setSelectedTag(id);
     setValue('tag', id);
   };
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- goal 추가 화면의 tag 추가 기능 구현

## 🎉 어떻게 해결했나요?
- react-query 반영된 sticker로 동작하는 스티커 추가 화면입니다.

### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/34956359/fddd3bdb-4f38-458b-b056-ec25708a2aaa


** 추가로 해결된 내용:
- [] goal 추가 화면에 생기는 스크롤 문제 해결 (overflow-hidden 설정 반영했습니다)
- [] 세부 버튼 사이즈를 글자수에 맞게 조정

