### PR TITLE
feat: status code 500에 대한 페이지 추가

### DIFF
--- a/src/apis/httpClient.ts
+++ b/src/apis/httpClient.ts
@@ -62,7 +62,17 @@ class HttpClient {
   }
 
   private onResponseRejected(error: AxiosError) {
-    if (!isAxiosError(error)) return Promise.reject(error);
+    if (!isAxiosError(error) || !error.response) return Promise.reject(error);
+
+    const { status: errorStatus } = error.response;
+    if (400 <= errorStatus && errorStatus < 500) {
+      if (errorStatus === 401) {
+        Cookies.remove('accessToken');
+        window.location.href = '/';
+      }
+    } else if (500 <= errorStatus) {
+      window.location.href = '/error';
+    }
 
     return Promise.reject(error.response);
   }

--- a/src/app/error/page.tsx
+++ b/src/app/error/page.tsx
@@ -1,0 +1,7 @@
+import { ErrorPageLayout } from '@/features/customErrors/components';
+
+const ErrorPage = () => {
+  return <ErrorPageLayout statusCode={500} />;
+};
+
+export default ErrorPage;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 서버에서 status code 500으로 보내주는 응답에 대한 보여줄 화면 추가

## 🎉 어떻게 해결했나요?
- axios interceptor를 통해 500 error를 감지하고, error 페이지로 라우팅

### 📚 Attachment (Option)
- N/A

