### PR TITLE
bug: 배포 전 버그 수정 (온보딩, 에러 페이지, 홈, 목표 추가, 상세 페이지)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,6 +36,11 @@ const nextConfig = {
         hostname: 'github.com',
         pathname: '/depromeet/amazing3-fe/assets/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+        pathname: '/a/**',
+      },
     ],
   },
 };

--- a/src/apis/httpClient.ts
+++ b/src/apis/httpClient.ts
@@ -65,12 +65,11 @@ class HttpClient {
     if (!isAxiosError(error) || !error.response) return Promise.reject(error);
 
     const { status: errorStatus } = error.response;
-    if (400 <= errorStatus && errorStatus < 500) {
-      if (errorStatus === 401) {
-        Cookies.remove('accessToken');
-        window.location.href = '/';
-      }
-    } else if (500 <= errorStatus) {
+    if (errorStatus === 401) {
+      Cookies.remove('accessToken');
+      window.location.href = '/';
+    }
+    if (500 == errorStatus) {
       window.location.href = '/error';
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,7 +23,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 100;
   src:
     local('Pretendard Thin'),
@@ -32,7 +32,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 200;
   src:
     local('Pretendard ExtraLight'),
@@ -41,7 +41,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 300;
   src:
     local('Pretendard Light'),
@@ -50,7 +50,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 400;
   src:
     local('Pretendard Regular'),
@@ -59,7 +59,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 500;
   src:
     local('Pretendard Medium'),
@@ -68,7 +68,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 600;
   src:
     local('Pretendard SemiBold'),
@@ -77,7 +77,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 700;
   src:
     local('Pretendard Bold'),
@@ -86,7 +86,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 800;
   src:
     local('Pretendard ExtraBold'),
@@ -95,7 +95,7 @@
 }
 
 @font-face {
-  font-family: Pretendard, Arial, sans-serif;
+  font-family: Pretendard;
   font-weight: 900;
   src:
     local('Pretendard Black'),

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,14 +1,7 @@
-import { api } from '@/apis';
-import PrefetchHydration from '@/contexts/reactQuery/PrefetchHydration';
 import { LifeMap } from '@/features/home/components';
-import type { GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
 
 const HomePage = () => {
-  return (
-    <PrefetchHydration queryKey={['goals']} queryFn={() => api.get<GoalResponse>('/goal')}>
-      <LifeMap />
-    </PrefetchHydration>
-  );
+  return <LifeMap />;
 };
 
 export default HomePage;

--- a/src/app/login/oauth2/code/google/page.tsx
+++ b/src/app/login/oauth2/code/google/page.tsx
@@ -29,7 +29,7 @@ const GoogleLogin = () => {
   useEffect(() => {
     setMemberData({ ...memberData });
     if (isLogin) {
-      router.push(memberData?.username ? '/home' : '/member/new/nickname');
+      router.push(memberData?.username ? '/home' : '/onboarding');
     }
   }, [memberData]);
 

--- a/src/features/customErrors/components/errorPageLayout/ErrorPageLayout.tsx
+++ b/src/features/customErrors/components/errorPageLayout/ErrorPageLayout.tsx
@@ -52,6 +52,7 @@ export const ErrorPageLayout = ({ statusCode }: ErrorPageLayoutProps) => {
               width={270}
               height={130}
               alt={`${statusCode}_error_image`}
+              priority
             />
             <Image src={ErrorTextImage} width={211} height={54} alt="error" />
           </div>

--- a/src/features/goal/components/detail/DeleteGoalButtomSheet.tsx
+++ b/src/features/goal/components/detail/DeleteGoalButtomSheet.tsx
@@ -22,9 +22,6 @@ export const DeleteGoalButtomSheet = ({ open, onClose }: DeleteGoalButtomSheetPr
   const router = useRouter();
 
   useEffect(() => {
-    if (isError) {
-      window.alert('목표 삭제에 실패했습니다.');
-    }
     if (isSuccess) {
       onClose();
       router.back();

--- a/src/features/goal/components/detail/DetailFooterButton.tsx
+++ b/src/features/goal/components/detail/DetailFooterButton.tsx
@@ -13,7 +13,7 @@ export const DetailFooterButton = () => {
   };
 
   return (
-    <>
+    <div className="flex items-center justify-between">
       <button
         className="flex justify-center items-center bg-gray-20 gap-7xs rounded-[100px] px-2xs py-3xs"
         onClick={handleClickBackButton}
@@ -31,6 +31,6 @@ export const DetailFooterButton = () => {
           <ArrowIcon className="rotate-180" />
         </button>
       </Link>
-    </>
+    </div>
   );
 };

--- a/src/features/goal/components/detail/DetailLayout.tsx
+++ b/src/features/goal/components/detail/DetailLayout.tsx
@@ -21,7 +21,7 @@ export const DetailLayout = ({ header, sticker, body, footer }: LayoutProps) => 
       <div className="absolute w-full top-[320px] bg-white rounded-lg pt-3xs">
         <div className="p-4xs px-sm">{body}</div>
       </div>
-      <div className="p-xs absolute w-full bottom-0 flex items-center justify-between">{footer}</div>
+      <div className="p-xs absolute w-full bottom-0">{footer}</div>
     </>
   );
 };

--- a/src/features/goal/components/detail/GoalDetailContent.tsx
+++ b/src/features/goal/components/detail/GoalDetailContent.tsx
@@ -28,11 +28,6 @@ export const GoalDetailContent = ({ id }: { id: number }) => {
         description,
       });
     }
-
-    if (isError) {
-      window.alert('목표 조회에 실패했습니다.');
-      router.push('/home');
-    }
   }, [goal, id, isError, router, setGoalData]);
 
   return (

--- a/src/features/goal/components/new/MoreForm.tsx
+++ b/src/features/goal/components/new/MoreForm.tsx
@@ -26,9 +26,6 @@ export const MoreForm = () => {
   const { mutate, isError, data } = useCreateGoal();
 
   useEffect(() => {
-    if (isError) {
-      window.alert('목표 생성에 실패했습니다.');
-    }
     if (data) {
       setGoalData(data);
       router.push('/goal/detail/saved');

--- a/src/features/goal/components/new/StickerForm.tsx
+++ b/src/features/goal/components/new/StickerForm.tsx
@@ -42,7 +42,7 @@ export const StickerForm = () => {
                 {stickerData?.map(({ id, name, url }) => (
                   <button key={id} className="flex flex-col items-center" onClick={() => handleClickSticker(id)}>
                     <div className={`p-5xs rounded-lg ${selectedSticker === id && 'bg-blue-10'}`}>
-                      <Image src={url} alt={name} width={150} height={150} />
+                      <Image src={url} alt={name} width={150} height={150} priority />
                     </div>
                   </button>
                 ))}

--- a/src/features/home/components/lifeMap/LifeMap.tsx
+++ b/src/features/home/components/lifeMap/LifeMap.tsx
@@ -73,9 +73,9 @@ export const LifeMap = () => {
       </div>
       <div className="flex gap-5xs px-xs pt-5xs mt-[18px] w-full">
         <ShareButton isLoading={isDownloading} onClick={onDownloadImage} />
-        <Button>
-          <Link href="/goal/new/goal">목표 추가하기</Link>
-        </Button>
+        <Link href="/goal/new/goal" className="w-full">
+          <Button>목표 추가하기</Button>
+        </Link>
       </div>
     </div>
   );

--- a/src/features/home/components/lifeMap/LifeMap.tsx
+++ b/src/features/home/components/lifeMap/LifeMap.tsx
@@ -56,7 +56,7 @@ export const LifeMap = () => {
             <div className="absolute inset-x-0">
               <MapSwiper>
                 {participatedGoalsArray?.map((goals, index) => (
-                  <SwiperSlide key={goals[0]?.id}>
+                  <SwiperSlide key={goals[0].id}>
                     {!(index % 2) ? (
                       <MapCardPositioner
                         type="A"

--- a/src/features/home/components/lifeMap/LifeMap.tsx
+++ b/src/features/home/components/lifeMap/LifeMap.tsx
@@ -2,12 +2,11 @@
 
 import { useRef } from 'react';
 import Link from 'next/link';
-import { useAtom } from 'jotai';
 import { SwiperSlide } from 'swiper/react';
 
 import StarBg from '@/app/home/startBg';
 import { Avatar, Button, ContentWrapper } from '@/components';
-import { nicknameAtom } from '@/features/member/atoms';
+import { useGetMemberData } from '@/hooks/reactQuery/auth';
 import { useGetGoals } from '@/hooks/reactQuery/goal';
 import { useDownloadImage } from '@/hooks/useDownloadImage';
 
@@ -19,7 +18,7 @@ import { MapSwiper } from '../mapSwiper';
 import { ShareButton } from '../shareButton';
 
 export const LifeMap = () => {
-  const nickname = useAtom(nicknameAtom);
+  const { data: memberData } = useGetMemberData();
   const { data: goalsData } = useGetGoals();
 
   const downloadSectionRef = useRef<HTMLElement>(null);
@@ -32,15 +31,19 @@ export const LifeMap = () => {
     <div className="w-full h-[100vh] flex flex-col items-center justify-between pb-xs">
       <div className="w-[390px] relative pt-xs">
         <span className="absolute right-[24px]">
-          <Avatar size={40} />
+          <Avatar size={40} profileImage={memberData?.image} />
         </span>
         <ContentWrapper
           title={
             <>
               반짝반짝 빛날
               <br />
-              {nickname}님의
-              <br />
+              {memberData?.nickname && (
+                <>
+                  {memberData.nickname} 님의
+                  <br />
+                </>
+              )}
               앞날을 응원해요!
             </>
           }
@@ -52,8 +55,8 @@ export const LifeMap = () => {
           <div className="h-[520px]">
             <div className="absolute inset-x-0">
               <MapSwiper>
-                {participatedGoalsArray.map((goals, index) => (
-                  <SwiperSlide key={goals[0].id}>
+                {participatedGoalsArray?.map((goals, index) => (
+                  <SwiperSlide key={goals[0]?.id}>
                     {!(index % 2) ? (
                       <MapCardPositioner
                         type="A"

--- a/src/features/member/types/form.ts
+++ b/src/features/member/types/form.ts
@@ -9,4 +9,5 @@ export interface MemberProps {
   username: string;
   nickname: string;
   birth: string;
+  image: string;
 }

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -22,7 +22,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
         회고를 적고,
       </>
     ),
-    sticker: <Image src={WritingSticker} width={268} height={268} alt="onboarding_image_1" />,
+    sticker: <Image src={WritingSticker} width={268} height={268} alt="onboarding_image_1" priority />,
   },
   {
     title: (
@@ -32,7 +32,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
         목표와 계획을 세워보세요.
       </>
     ),
-    sticker: <Image src={TargetSticker} width={268} height={268} alt="onboarding_image_2" />,
+    sticker: <Image src={TargetSticker} width={268} height={268} alt="onboarding_image_2" priority />,
   },
   {
     title: (
@@ -42,7 +42,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
         완성될 거예요.
       </>
     ),
-    sticker: <Image src={MapSticker} width={268} height={268} alt="onboarding_image_3" />,
+    sticker: <Image src={MapSticker} width={268} height={268} alt="onboarding_image_3" priority />,
   },
 ];
 
@@ -59,9 +59,9 @@ export const OnboardingBody = () => {
         </OnboardingSwiper>
       </div>
       <div className="h-full flex flex-col-reverse">
-        <Button className="flex-grow-1">
-          <Link href={{ pathname: '/member/new/nickname' }}>시작하기</Link>
-        </Button>
+        <Link href={{ pathname: '/member/new/nickname' }}>
+          <Button className="flex-grow-1">시작하기</Button>
+        </Link>
       </div>
     </div>
   );

--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -34,7 +34,7 @@ export const useDownloadImage = (imageRef: RefObject<HTMLElement>) => {
       });
 
       // FIXME: 다운로드 되는 이미지 파일 이름 수정 필요
-      const IMAGE_FILE_NAME = 'file-name-test';
+      const IMAGE_FILE_NAME = '별이되고_싶은_반디부디의_인생지도';
       downloadFile(imageUrl, IMAGE_FILE_NAME);
     } catch (error) {
       // TODO: 이미지 다운로드 실패 시, 추가 에러 처리 필요

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,9 +2,11 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 export async function middleware(request: NextRequest) {
-  const token = request.cookies.get('accessToken');
+  if (process.env.NODE_ENV !== 'development') {
+    const token = request.cookies.get('accessToken');
 
-  return token ? NextResponse.next() : NextResponse.redirect(new URL('/', request.url));
+    return token ? NextResponse.next() : NextResponse.redirect(new URL('/', request.url));
+  }
 }
 
 export const config = {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
-  [사용자의 로그인 후 계정 생성 과정에 대한 버그 수정](https://github.com/depromeet/amazing3-fe/pull/56/commits/f64f7d0115f4bdeb978a8b41f8978c9fad8250ca)
- [홈, 목표 추가, 상세 확인 페이지 버그 수정](https://github.com/depromeet/amazing3-fe/pull/56/commits/0f0f123da9b97490b665e982a9969b32f22eeb95)

## 🎉 어떻게 해결했나요?
- oauth 성공 후 계정 정보가 없을 시 onboading 페이지로 이동하도록 경로 수정
- nickname로 이동하는 link가 버튼이 아닌 text에 적용된 부분 -> 버튼으로 변경
- 이미지 출력이 오래걸리는 문제 -> priority 적용으로 해결
- home 다운로드 시 파일 이름 변경
- pretendard font 반영 안되는 문제 해결
- 404, 500 이미지 preloading으로 변경
- db에서 가져오는 sticker 이미지 preloading으로 변경
- 공통 컴포넌트 사용으로 인해 버튼 디자인 깨지는 문제 수정
- cache에 반영 안된 라이브러리 추가
- home 화면에 적용한 hydration에서 오류를 유발하는 코드 일단 제거
- 에러 처리 로직 보강 및 개발 환경 시 바이페스할 수 있는 로직 추가
- redirection에 따른 alert 삭제
- 사용자 image 출력으로 변경

### 📚 Attachment (Option)
- N/A

