### PR TITLE
bug: 홈화면에서 닉네임 없을 경우 레이아웃에 br 추가 (임시)

### DIFF
--- a/src/features/home/components/lifeMap/LifeMap.tsx
+++ b/src/features/home/components/lifeMap/LifeMap.tsx
@@ -36,6 +36,11 @@ export const LifeMap = () => {
         <ContentWrapper
           title={
             <>
+              {!memberData?.nickname && (
+                <>
+                  <br />
+                </>
+              )}
               반짝반짝 빛날
               <br />
               {memberData?.nickname && (


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 닉네임이 없는 경우 화면 레이아웃이 위로 쏠리는 이슈 있었습니다.

## 🎉 어떻게 해결했나요?
- 임시입니다... br 태그로 추가했습니다... 추후에 스타일로 수정하겠습니다 ㅠ

### 📚 Attachment (Option)
- N/A

