### PR TITLE
fix: ios에서 이미지 다운로드가 제대로 되지 않는 버그 해결

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -68,6 +68,7 @@ const RAW_RUNTIME_STATE =
           ["jotai", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:2.6.0"],\
           ["js-cookie", "npm:3.0.5"],\
           ["lint-staged", "npm:15.0.2"],\
+          ["modern-screenshot", "npm:4.4.37"],\
           ["next", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:14.0.2"],\
           ["postcss", "npm:8.4.31"],\
           ["prettier", "npm:3.1.0"],\
@@ -10087,6 +10088,7 @@ const RAW_RUNTIME_STATE =
           ["jotai", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:2.6.0"],\
           ["js-cookie", "npm:3.0.5"],\
           ["lint-staged", "npm:15.0.2"],\
+          ["modern-screenshot", "npm:4.4.37"],\
           ["next", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:14.0.2"],\
           ["postcss", "npm:8.4.31"],\
           ["prettier", "npm:3.1.0"],\
@@ -16633,6 +16635,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/mkdirp-classic-npm-0.5.3-3b5c991910-10c0.zip/node_modules/mkdirp-classic/",\
         "packageDependencies": [\
           ["mkdirp-classic", "npm:0.5.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["modern-screenshot", [\
+      ["npm:4.4.37", {\
+        "packageLocation": "./.yarn/cache/modern-screenshot-npm-4.4.37-bffef63713-10c0.zip/node_modules/modern-screenshot/",\
+        "packageDependencies": [\
+          ["modern-screenshot", "npm:4.4.37"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -63,7 +63,6 @@ const RAW_RUNTIME_STATE =
           ["eslint-plugin-simple-import-sort", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:10.0.0"],\
           ["eslint-plugin-storybook", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:0.6.15"],\
           ["eslint-plugin-unused-imports", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:3.0.0"],\
-          ["html-to-image", "npm:1.11.11"],\
           ["husky", "npm:8.0.3"],\
           ["jotai", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:2.6.0"],\
           ["js-cookie", "npm:3.0.5"],\
@@ -10083,7 +10082,6 @@ const RAW_RUNTIME_STATE =
           ["eslint-plugin-simple-import-sort", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:10.0.0"],\
           ["eslint-plugin-storybook", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:0.6.15"],\
           ["eslint-plugin-unused-imports", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:3.0.0"],\
-          ["html-to-image", "npm:1.11.11"],\
           ["husky", "npm:8.0.3"],\
           ["jotai", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:2.6.0"],\
           ["js-cookie", "npm:3.0.5"],\
@@ -14704,15 +14702,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/html-tags-npm-3.3.1-c8f411791b-10c0.zip/node_modules/html-tags/",\
         "packageDependencies": [\
           ["html-tags", "npm:3.3.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["html-to-image", [\
-      ["npm:1.11.11", {\
-        "packageLocation": "./.yarn/cache/html-to-image-npm-1.11.11-faab8eba97-10c0.zip/node_modules/html-to-image/",\
-        "packageDependencies": [\
-          ["html-to-image", "npm:1.11.11"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@vercel/analytics": "^1.1.1",
     "@vercel/speed-insights": "^1.0.2",
     "class-variance-authority": "^0.7.0",
-    "html-to-image": "^1.11.11",
     "jotai": "^2.6.0",
     "js-cookie": "^3.0.5",
     "modern-screenshot": "^4.4.37",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "html-to-image": "^1.11.11",
     "jotai": "^2.6.0",
     "js-cookie": "^3.0.5",
+    "modern-screenshot": "^4.4.37",
     "next": "14.0.2",
     "react": "^18",
     "react-dom": "^18",

--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -1,6 +1,9 @@
 import { type RefObject, useState } from 'react';
 import { domToJpeg } from 'modern-screenshot';
 
+import { shareImage } from '@/utils/image';
+import { isIos } from '@/utils/userAgent';
+
 import { backgroundImage } from '../../styles/theme';
 
 const downloadFile = (url: string, filename: string) => {
@@ -32,7 +35,11 @@ export const useDownloadImage = (imageRef: RefObject<HTMLElement>) => {
       });
 
       const IMAGE_FILE_NAME = '별이되고_싶은_반디부디의_인생지도';
-      downloadFile(imageUrl, IMAGE_FILE_NAME);
+      if (isIos()) {
+        shareImage(imageUrl, IMAGE_FILE_NAME);
+      } else {
+        downloadFile(imageUrl, IMAGE_FILE_NAME);
+      }
     } catch (error) {
       // TODO: 이미지 다운로드 실패 시, 추가 에러 처리 필요
       console.error(error);

--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -1,5 +1,5 @@
 import { type RefObject, useState } from 'react';
-import { toJpeg } from 'html-to-image';
+import { domToJpeg } from 'modern-screenshot';
 
 import { backgroundImage } from '../../styles/theme';
 
@@ -23,17 +23,14 @@ export const useDownloadImage = (imageRef: RefObject<HTMLElement>) => {
     try {
       setIsDownloading(true);
 
-      const imageUrl = await toJpeg(image, {
-        includeQueryParams: true,
+      const imageUrl = await domToJpeg(image, {
         style: {
           backgroundImage: backgroundImage.gradient1,
-          paddingTop: '24px',
-          paddingBottom: '24px',
         },
         height: 700,
+        scale: 4,
       });
 
-      // FIXME: 다운로드 되는 이미지 파일 이름 수정 필요
       const IMAGE_FILE_NAME = '별이되고_싶은_반디부디의_인생지도';
       downloadFile(imageUrl, IMAGE_FILE_NAME);
     } catch (error) {

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,26 @@
+export const shareImage = async (imageUrl: string, fileName: string) => {
+  // TODO: 추후에 에러 처리 변경
+  if (!navigator.canShare) {
+    alert('지원하지 않는 브라우저입니다.');
+    return;
+  }
+
+  const image = await fetch(imageUrl);
+  const blob = await image.blob();
+  const file = new File([blob], `${fileName}.jpeg`, {
+    type: 'image/jpeg',
+  });
+  const shareData = {
+    title: fileName,
+    text: fileName,
+    files: [file],
+  };
+
+  // TODO: 추후에 에러 처리 변경
+  if (!navigator.canShare({ files: [file] })) {
+    alert('공유할 수 없는 파일입니다');
+    return;
+  }
+
+  await navigator.share(shareData);
+};

--- a/src/utils/userAgent.ts
+++ b/src/utils/userAgent.ts
@@ -1,0 +1,1 @@
+export const isIos = () => Boolean(navigator.userAgent.match(/iPhone|iPad/i));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5988,7 +5988,6 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^10.0.0"
     eslint-plugin-storybook: "npm:^0.6.15"
     eslint-plugin-unused-imports: "npm:^3.0.0"
-    html-to-image: "npm:^1.11.11"
     husky: "npm:^8.0.3"
     jotai: "npm:^2.6.0"
     js-cookie: "npm:^3.0.5"
@@ -9898,13 +9897,6 @@ __metadata:
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
   checksum: 680165e12baa51bad7397452d247dbcc5a5c29dac0e6754b1187eee3bf26f514bc1907a431dd2f7eb56207611ae595ee76a0acc8eaa0d931e72c791dd6463d79
-  languageName: node
-  linkType: hard
-
-"html-to-image@npm:^1.11.11":
-  version: 1.11.11
-  resolution: "html-to-image@npm:1.11.11"
-  checksum: 0b6349221ad253dfca01d165c589d44341e942faf0273aab28c8b7d86ff2922d3e8e6390f57bf5ddaf6bac9a3b590a8cdaa77d52a363354796dd0e0e05eb35d2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5993,6 +5993,7 @@ __metadata:
     jotai: "npm:^2.6.0"
     js-cookie: "npm:^3.0.5"
     lint-staged: "npm:^15.0.2"
+    modern-screenshot: "npm:^4.4.37"
     next: "npm:14.0.2"
     postcss: "npm:^8"
     prettier: "npm:^3.1.0"
@@ -11604,6 +11605,13 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
+  languageName: node
+  linkType: hard
+
+"modern-screenshot@npm:^4.4.37":
+  version: 4.4.37
+  resolution: "modern-screenshot@npm:4.4.37"
+  checksum: f1904831b49e657ff3b6dffa4e5ac7387192e2189d3cbafb486c011a07e1765cc63026021ca793483bbed31bdd6cb553f9f700bb40e1744c1c92f1af933f44dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- ios / safari / firefox 에서 다운로드한 이미지가 제대로 출력되지 않는 이슈가 있었어요
  - 텍스트 누락 / 스티커 이미지 누락


| AS-IS | TO-BE |
|--------|--------|
| <img src="https://github.com/depromeet/amazing3-fe/assets/80238096/ddec10ee-25b5-40b8-b56d-748c7cab2539" width="200px" /> | <img src="https://github.com/depromeet/amazing3-fe/assets/80238096/2b2cd38d-5442-4b41-b186-29c32d9b687d" width="200px" /> |



## 🎉 어떻게 해결했나요?

### 1. 이미지 다운로드 이슈 해결
- img가 로드되기 전 + decode되기 전에 DOM을 이미지로 변환하기 때문에 발생한 버그
   - html을 이미지로 변환하는 라이브러리인 html-to-image에 ios 이미지가 제대로 다운되지 않는 이슈가 있었어요
   - https://github.com/bubkoo/html-to-image/issues/361

- 위 버그를 수정한 modern-screenshot 으로 이미지 다운로드 라이브러리 변경

### 2. ios에서 이미지 다운로드 -> 이미지 공유 기능으로 변경
- 모바일 사용자 경험을 위해 공유 기능으로 수정

| AS-IS | TO-BE |
|--------|--------|
| <img src="https://github.com/depromeet/amazing3-fe/assets/80238096/44916038-0052-49af-addf-8fd541632156" width="200px" /> | <img src="https://github.com/depromeet/amazing3-fe/assets/80238096/fb5faffc-90f4-4505-a115-7afd49226f7d" width="200px" /> |
| 이미지 다운로드 | 이미지 공유 | 



### 📚 Attachment (Option)
- preview로 이미지 다운로드 후 이미지가 정상적으로 출력되는지 확인 부탁드립니다!

