### PR TITLE
fix: 다운로드 이미지 상단에 여백 추가

### DIFF
--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -29,6 +29,7 @@ export const useDownloadImage = (imageRef: RefObject<HTMLElement>) => {
       const imageUrl = await domToJpeg(image, {
         style: {
           backgroundImage: backgroundImage.gradient1,
+          paddingTop: '24px',
         },
         height: 700,
         scale: 4,


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 다운로드 이미지 상단에 여백 추가

## 🎉 어떻게 해결했나요?
- 다운로드 되는 이미지 상단에 여백 추가
  - 프리뷰에서는 여백이 제대로 나오는데 배포하니까 여백이 안보이는 이슈가 있어서 우선 paddingTop 추가했습니다!


- 프리뷰 때 다운로드 되는 이미지랑 배포에서 다운로드 되는 이미지랑 여백이 달라서 테스트가 어렵네요🥹
 
