### PR TITLE
bug: invalidQueries 적용 이슈 해결

### DIFF
--- a/src/contexts/reactQuery/QueryClientProvider.tsx
+++ b/src/contexts/reactQuery/QueryClientProvider.tsx
@@ -10,9 +10,9 @@ const queryClientOption: QueryClientConfig = {
   defaultOptions: {
     queries: {
       retry: false,
-      refetchOnMount: false,
       refetchOnWindowFocus: false,
       networkMode: 'always',
+      staleTime: Infinity,
     },
     mutations: {
       networkMode: 'always',

--- a/src/hooks/reactQuery/goal/useDeleteGoal.ts
+++ b/src/hooks/reactQuery/goal/useDeleteGoal.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 
@@ -7,7 +7,10 @@ type GoalRequestParams = {
 };
 
 export const useDeleteGoal = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (data: GoalRequestParams) => api.delete(`/goal/${data.goalId}`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['goals'] }),
   });
 };

--- a/src/hooks/reactQuery/goal/useGetGoals.ts
+++ b/src/hooks/reactQuery/goal/useGetGoals.ts
@@ -18,6 +18,5 @@ export const useGetGoals = () => {
   return useQuery<GoalResponse>({
     queryKey: ['goals'],
     queryFn: () => api.get<GoalResponse>('/goal'),
-    gcTime: 0,
   });
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [react-query 적용 이슈 (hydtration, invalidateQueries)](https://www.notion.so/depromeet/react-query-hydtration-invalidateQueries-02589dccff924b76affedba7f19ee1e4) 중 invalidQueries 적용 이슈

## 🎉 어떻게 해결했나요?
- `refetchOnMount: false` 옵션으로 인해 마운트 시 refetch가 되지 못해 invalidQueries가 적용되지 못한 걸로 파악되었습니다.
  - 이럴 경우 stateTime을 주어야 일반적인 mount 시에는 refetch를 하지 않습니다!

- 저희 서비스 현재 단계 기준으로, 적절한(?) staleTime은 `Infinity`라고 생각이 들어 모든 query에 `staleTime: Infinity` 적용해 주었습니다.

### 📚 Attachment (Option)
- 항상 staleTime과 gcTime(구 cacheTime)에 대한 고민이 가장 알쏭달쏭한데.... 더 좋은 의견 있으시면 무한 감사드리겠습니다 많관부..

