### PR TITLE
bug: tag, sticker 돌아오면 선택 안되어 있는 문제 해결

### DIFF
--- a/src/features/goal/components/new/StickerForm.tsx
+++ b/src/features/goal/components/new/StickerForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -15,9 +15,13 @@ import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 export const StickerForm = () => {
-  const { register, setValue } = useFormContext<GoalFormValues>();
-  const [selectedSticker, setSelectedSticker] = useState<number | null>(null);
+  const { register, getValues, setValue } = useFormContext<GoalFormValues>();
+  const [selectedSticker, setSelectedSticker] = useState<number | null>();
   const { data: stickerData } = useGetStickers();
+
+  useEffect(() => {
+    setSelectedSticker(getValues('sticker'));
+  }, [getValues]);
 
   const handleClickSticker = (id: number) => {
     setSelectedSticker(id);

--- a/src/features/goal/components/new/TagForm.tsx
+++ b/src/features/goal/components/new/TagForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import Link from 'next/link';
 
@@ -14,9 +14,13 @@ import FormHeader from './FormHeader';
 import FormLayout from './FormLayout';
 
 export const TagForm = () => {
-  const { register, setValue } = useFormContext<GoalFormValues>();
-  const [selectedTag, setSelectedTag] = useState<number | null>(null);
+  const { register, getValues, setValue } = useFormContext<GoalFormValues>();
+  const [selectedTag, setSelectedTag] = useState<number | null>();
   const { data: tagsData } = useGetTags();
+
+  useEffect(() => {
+    setSelectedTag(getValues('tag'));
+  }, [getValues]);
 
   const handleClickTag = (id: number) => {
     setSelectedTag(id);


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [tag, sticker 돌아오면 선택 안되어 있는 문제 해결](https://www.notion.so/depromeet/tag-sticker-27cb63aef63a4fd4b2f5fe55d38bc7d6?pvs=4) 

## 🎉 어떻게 해결했나요?
- getValues 값을 통해 해당하는 값이 지정되어 있으면 반영하도록 수정

### 📚 Attachment (Option)
https://github.com/depromeet/amazing3-fe/assets/34956359/9a74063e-d5af-45f9-9e17-b4d8065f31db


