### PR TITLE
bug: 사용자 상태에 따른 onboarding 시작하기 기능 분리 및 metadata 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,9 @@ import './globals.css';
 
 export const metadata: Metadata = {
   metadataBase: new URL(META.url),
+  alternates: {
+    canonical: '/',
+  },
   title: META.title,
   description: META.description,
   keywords: [...META.keyword],
@@ -40,9 +43,6 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="kr">
-      <head>
-        <link rel="canonical" href="https://www.bandiboodi.com" />
-      </head>
       <body className={`${pretendard.variable} ${insungIt.variable}`}>
         <Providers>
           <div className="layout font-pretendard">{children}</div>

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,4 +1,28 @@
 import type { PropsWithChildren } from 'react';
+import type { Metadata } from 'next';
+
+import { META_ONBOARDING } from '@/constants/metadata';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(META_ONBOARDING.url),
+  alternates: {
+    canonical: '/',
+  },
+  title: META_ONBOARDING.title,
+  description: META_ONBOARDING.description,
+  openGraph: {
+    title: META_ONBOARDING.title,
+    description: META_ONBOARDING.description,
+    siteName: META_ONBOARDING.siteName,
+    locale: 'ko_KR',
+    type: 'website',
+    url: META_ONBOARDING.url,
+  },
+  twitter: {
+    title: META_ONBOARDING.title,
+    description: META_ONBOARDING.description,
+  },
+};
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
   return <div className="w-full h-[100dvh] bg-gradient2 pt-[10vh] pb-xs">{children}</div>;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -17,10 +17,16 @@ export const metadata: Metadata = {
     locale: 'ko_KR',
     type: 'website',
     url: META_ONBOARDING.url,
+    images: {
+      url: META_ONBOARDING.ogImage,
+    },
   },
   twitter: {
     title: META_ONBOARDING.title,
     description: META_ONBOARDING.description,
+    images: {
+      url: META_ONBOARDING.ogImage,
+    },
   },
 };
 

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -3,9 +3,26 @@ export const META = {
   siteName: '반디부디',
   description:
     '이루고 싶은 목표를 지도에 남겨보세요. 목표와 관련된 다양한 스티커를 붙여 나만의 지도를 만들고 공유할 수 있어요.',
-  keyword: ['반디부디', 'bandiboodi', '인생지도', '신년계획', '계획', '목표설정', '목표달성', '자기계발'],
-  url: 'https://www.bandiboodi.com/',
+  keyword: [
+    '반디부디',
+    'bandiboodi',
+    '인생지도',
+    '신년계획',
+    '계획',
+    '목표설정',
+    '목표달성',
+    '자기계발',
+    '회고',
+    '응원',
+  ],
+  url: 'https://www.bandiboodi.com',
   googleVerification: process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION,
-  iconImage: '/icon.ico',
   ogImage: '/opengraph-image.png',
+} as const;
+
+export const META_ONBOARDING = {
+  title: '반디부디: 내가 직접 그리는 나의 인생지도',
+  description:
+    '내가 걸어온 길을 떠올리면서 회고를 적고, 내가 걸어갈 길의 방향을 짚어가면서 목표와 계획을 세워보세요. 한 조각씩 채우다 보면 나만의 인생지도가 완성될 거에요.',
+  url: 'https://www.bandiboodi.com/onboarding',
 } as const;

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -22,7 +22,9 @@ export const META = {
 
 export const META_ONBOARDING = {
   title: '반디부디: 내가 직접 그리는 나의 인생지도',
+  siteName: '반디부디',
   description:
     '내가 걸어온 길을 떠올리면서 회고를 적고, 내가 걸어갈 길의 방향을 짚어가면서 목표와 계획을 세워보세요. 한 조각씩 채우다 보면 나만의 인생지도가 완성될 거에요.',
   url: 'https://www.bandiboodi.com/onboarding',
+  ogImage: '/opengraph-image.png',
 } as const;

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -1,13 +1,16 @@
 'use client';
 
+import { useEffect } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { SwiperSlide } from 'swiper/react';
 
 import MapSticker from '@/assets/stickers/map_sticker.png';
 import TargetSticker from '@/assets/stickers/target_sticker.png';
 import WritingSticker from '@/assets/stickers/writing_sticker.png';
 import { Button } from '@/components';
+import { Spinner } from '@/components/atoms/spinner';
+import { useGetMemberData } from '@/hooks/reactQuery/auth';
 
 import { OnboardingLayout } from '../onboardingLayout';
 import type { OnboardingLayoutProps } from '../onboardingLayout/onboardingLayout';
@@ -47,6 +50,24 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
 ];
 
 export const OnboardingBody = () => {
+  const router = useRouter();
+  const { data: memberData, refetch, isFetching } = useGetMemberData({ enabled: false });
+
+  useEffect(() => {
+    if (memberData) {
+      const nickname = memberData?.nickname;
+      if (nickname) {
+        router.push('/home');
+      } else {
+        router.push('/member/new/nickname');
+      }
+    }
+  }, [memberData, router]);
+
+  const handleClick = () => {
+    refetch();
+  };
+
   return (
     <div className="w-full h-full px-xs flex flex-col">
       <div className="h-full">
@@ -59,9 +80,9 @@ export const OnboardingBody = () => {
         </OnboardingSwiper>
       </div>
       <div className="h-full flex flex-col-reverse">
-        <Link href={{ pathname: '/member/new/nickname' }}>
-          <Button className="flex-grow-1">시작하기</Button>
-        </Link>
+        <Button onClick={handleClick} disabled={isFetching} className="flex-grow-1">
+          {isFetching ? <Spinner /> : '시작하기'}
+        </Button>
       </div>
     </div>
   );

--- a/src/hooks/reactQuery/auth/useCreateMemberData.ts
+++ b/src/hooks/reactQuery/auth/useCreateMemberData.ts
@@ -1,10 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 import type { NewMemberFormValues as MemberRequest } from '@/features/member/types';
 
 export const useCreateMemberData = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (data: MemberRequest) => api.put('/my', data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['memberData'] }),
   });
 };

--- a/src/hooks/reactQuery/auth/useGetMemberData.ts
+++ b/src/hooks/reactQuery/auth/useGetMemberData.ts
@@ -3,9 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '@/apis';
 import type { MemberProps } from '@/features/member/types';
 
-export const useGetMemberData = () => {
+interface UseGetMemberDataProps {
+  enabled?: boolean;
+}
+
+export const useGetMemberData = ({ enabled = true }: UseGetMemberDataProps = {}) => {
   return useQuery<MemberProps>({
     queryKey: ['memberData'],
     queryFn: () => api.get<MemberProps>('/my'),
+    enabled,
   });
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 1) onboarding 페이지가 SEO에 등록되면서 의미있는 정보를 제공하려고 내용에 변화를 주었습니다.
- 2) onboarding에서 사용자의 상태에 따라 시작하기 버튼 동작을 다르게 지정하여 해당 페이지로 직접 들어와도 사용자 경로에 문제가 생기지 않도록 수정했습니다.
- 3) 처음 nickname 등록 후 /home 화면에 username이 출력되지 않는 문제를 해결했습니다.

## 🎉 어떻게 해결했나요?
1) metadata 정보 추가
![image](https://github.com/depromeet/amazing3-fe/assets/34956359/582c7e91-9f6c-4bda-924d-d87a2e45e68e)

2) react-query의 [enabled 옵션](https://tanstack.com/query/v4/docs/react/guides/disabling-queries)을 사용하여 아래의 문제를 해결했습니다.

조건 | AS-IS | TO-BE |
|----|----|----|
| accessToken 없이 onboarding 화면 접속 | 401 에러로 즉시 '/' 경로로 이동 | `시작하기` 버튼 클릭 전까지 onboarding 페이지 출력 |
| nickname이 있는 사용자가 유효한 토큰이 있는 상태에서 onboarding 화면 접속 | nickname 설정하는 화면으로 이동 | `home`으로 이동 |

3) invalidateQueries 설정으로 home에서 사용자 정보 조회 시 반영된 nickname 출력 가능하도록 설정.

### 📚 Attachment (Option)
https://github.com/depromeet/amazing3-fe/assets/34956359/f65c83e5-27d5-4111-bb1a-536186eb5fe3


