### PR TITLE
feat: 현재 페이지 이미지 다운로드 -> 전체 페이지 이미지 다운로드로 변경

### DIFF
--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -6,6 +6,8 @@ import { isIos } from '@/utils/userAgent';
 
 import { backgroundImage } from '../../styles/theme';
 
+import { useGetGoals } from './reactQuery/goal';
+
 const downloadFile = (url: string, filename: string) => {
   const link = document.createElement('a');
 
@@ -17,6 +19,10 @@ const downloadFile = (url: string, filename: string) => {
 
 export const useDownloadImage = (imageRef: RefObject<HTMLElement>) => {
   const [isDownloading, setIsDownloading] = useState(false);
+
+  const { data: goalsData } = useGetGoals();
+
+  const getPageCount = () => Math.floor((goalsData?.goalsCount || 1) / 5) + 1;
 
   const onDownloadImage = async () => {
     const image = imageRef.current;
@@ -31,8 +37,18 @@ export const useDownloadImage = (imageRef: RefObject<HTMLElement>) => {
           backgroundImage: backgroundImage.gradient1,
           paddingTop: '24px',
         },
-        height: 700,
+        height: 670,
+        width: 390 * getPageCount(),
         scale: 4,
+        onCloneNode: (node) => {
+          const swiper = (node as HTMLElement).querySelector<HTMLElement>('.swiper');
+          const swiperWrapper = (node as HTMLElement).querySelector<HTMLElement>('.swiper-wrapper');
+
+          if (!swiper || !swiperWrapper) return;
+
+          swiper.style.overflow = 'visible';
+          swiperWrapper.style.transform = 'translate3d(0px, 0, 0)';
+        },
       });
 
       const IMAGE_FILE_NAME = '별이되고_싶은_반디부디의_인생지도';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 이미지 다운로드시, 전체 인생지도가 다운로드가 될 수 있도록 변경했어요

| AS-IS | TO-BE |
|--------|--------|
| <img src="https://github.com/depromeet/amazing3-fe/assets/80238096/efbe2d99-cc7a-4e03-a93e-226db5d2ebdb" width="200px" /> |<img src="https://github.com/depromeet/amazing3-fe/assets/80238096/8d978a8e-0e3d-42b1-b114-a093fbf59b4d" width="300px" /> |
| 한 페이지씩 다운로드 | 전체 페이지 다운로드 | 



## 🎉 어떻게 해결했나요?

### 이미지 다운로드 시, 인생 지도 스타일 변경
이미지 다운로드 라이브러리의 `onCloneNode` 옵션을 사용해서 클론된 html의 스타일을 변경하는 방식을 사용했어요
> 현재 사용중인 이미지 다운로드 라이브러리는 html을 클론 후 -> 이미지로 변경(html-to-image)하는 방식을 사용해요
  - 이미지 다운로드 시, 기존 swiper에 적용되어있는 `overflow:hidden` 속성을 `visible`로 변경해서 전체 인생지도가 보일 수 있도록 했어요
  - 어떤 페이지에서 다운로드해도 전체 인생지도가 다운로드될 수 있도록 `translate3d` 속성을 수정했어요

- 다운로드될 이미지의 넓이를 구하기 위해 goals의 개수를 통해 계산했어요

#### 2페이지 경우
<img src="https://github.com/depromeet/amazing3-fe/assets/80238096/8d978a8e-0e3d-42b1-b114-a093fbf59b4d" width="500px" />

#### 3페이지 경우
<img src="https://github.com/depromeet/amazing3-fe/assets/80238096/4fa67668-8bb6-4a04-8d96-38328bc8136f" width="700px" />

#### 4페이지 경우
<img src="https://github.com/depromeet/amazing3-fe/assets/80238096/13631b1f-5e89-4d8b-bc51-3d6dedb0e903" width="700px" />


### 📚 Attachment (Option)
- 코드.. 굉장히 마음에 안드는데요.. 
  - 이미지 다운로드를 하는데 goals의 개수를 알아야하는 점.. 강결합이 미쳤네요..
  - querySelector로 요소 가져와서 스타일을 일일이 변경하고 있다는 점..아주 불편합니다..

우선 Draft로 올려놓고 더 나은 방법이 있는지 고민해보도록하겠습니다 🗿


- 그리고 전체 다운로드가 나을지에 대한 고민도 좀 해봐야하겄습니다.. 모바일로 보니까 상당히 작습니다..