### PR TITLE
bug: 생년월일 입력시 닉네임이 undefined로 보이는 현상

### DIFF
--- a/src/features/member/components/new/BirthInputForm.tsx
+++ b/src/features/member/components/new/BirthInputForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 
@@ -22,9 +23,11 @@ export const BirthInputForm = () => {
    * TODO: 생년월일 검증 로직 추가
    */
 
-  if (!nickname) {
-    router.push('/member/new/nickname');
-  }
+  useEffect(() => {
+    if (!nickname) {
+      router.push('/member/new/nickname');
+    }
+  }, []);
 
   return (
     <FormLayout

--- a/src/features/member/components/new/BirthInputForm.tsx
+++ b/src/features/member/components/new/BirthInputForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useController, useFormContext } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
 
 import BirthIcon from '@/assets/icons/birth-icon.svg';
 import { Button, Input } from '@/components';
@@ -10,6 +11,7 @@ import type { NewMemberFormValues } from '../../types';
 import FormLayout from './FormLayout';
 
 export const BirthInputForm = () => {
+  const router = useRouter();
   const { register, getValues, control } = useFormContext<NewMemberFormValues>();
   const { field } = useController({ name: 'birth', control });
   const { onChange, value } = field;
@@ -20,9 +22,9 @@ export const BirthInputForm = () => {
    * TODO: 생년월일 검증 로직 추가
    */
 
-  /**
-   * TODO: API 연결 및 라우팅 추가
-   */
+  if (!nickname) {
+    router.push('/member/new/nickname');
+  }
 
   return (
     <FormLayout


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 첫 가입시 생년월일을 입력할 때, 새로고침 등으로 입력한 nickname이 초기화되어 `undefined`로 나타나는 현상

## 🎉 어떻게 해결했나요?
- 생년월일 입력 페이지에서 `react-hook-form`에 등록된 닉네임이 없을 경우, 닉네임 입력 페이지로 라우팅

### 📚 Attachment (Option)
- 해당 방법 말고 더 나은 방법이 있을까요.. 😢 아무리 생각해도 저는 이것 밖에..
- 추후 이미 온보딩 과정을 거친 유저에 대해서는 온보딩 과정 페이지에 접근할 수 없도록 하는 과정이 필요할 것 같아요

