### PR TITLE
chore: Google Analytics 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 
 import { META } from '@/constants';
 import Providers from '@/contexts/Providers';
+import { GoogleAnalytics } from '@/features/analyzer';
 
 import { insungIt, pretendard } from './fonts';
 
@@ -49,6 +50,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Analytics />
           <SpeedInsights />
         </Providers>
+
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/src/features/analyzer/GoogleAnalytics.tsx
+++ b/src/features/analyzer/GoogleAnalytics.tsx
@@ -1,0 +1,22 @@
+import Script from 'next/script';
+
+export const GoogleAnalytics = () => {
+  const measurementId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_MEASUREMENT_ID;
+
+  if (process.env.NODE_ENV === 'development') return null;
+
+  return (
+    <>
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`} />
+      <Script id="google-analytics">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '${measurementId}');
+        `}
+      </Script>
+    </>
+  );
+};

--- a/src/features/analyzer/index.ts
+++ b/src/features/analyzer/index.ts
@@ -1,0 +1,1 @@
+export { GoogleAnalytics } from './GoogleAnalytics';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [Google Analytics 적용](https://www.notion.so/depromeet/Google-Analytics-d56a2ec36baf4a1b84b66478c39da054?pvs=4)

## 🎉 어떻게 해결했나요?
- [Next 공식 문서](https://nextjs.org/docs/messages/next-script-for-ga)를 활용

### 📚 Attachment (Option)
- 우선 vercel에 GA 측정 ID를 환경 변수에 추가해뒀습니다
- 보통 `hotjar`와 `mixpanel`을 분석 툴로 많이 사용한다고 하는데, 모바일 환경을 고려한다면 `mixpanel`이 유저 행동과 이벤트를 중점적으로 분석해줘서 좋다고 하네요!
  - [Reference](https://www.fullsession.io/blog/hotjar-vs-mixpanel-vs-clicktale/)
- 그래서 `mixpanel`도 같이 붙여볼까 고려중이였는데 오버엔지니어링이라는 생각이 들긴하네요
  - 그리고 이벤트를 다루는 모든 함수에 로깅 함수를 달아줘야하는 것 같긴 합니다 ㅠ
- 혹시나 <ins>더 좋은 아이디어나 필요하다고 생각되는 기능</ins>이 있으면 말씀해주세요!
