### PR TITLE
bug: initialSlide가 0인 경우 Swiper가 출력되지 않는 이슈

### DIFF
--- a/src/features/home/components/mapSwiper/MapSwiper.tsx
+++ b/src/features/home/components/mapSwiper/MapSwiper.tsx
@@ -29,7 +29,7 @@ export const MapSwiper = ({ currentPosition, children }: MapSwiperProps) => {
   }, [currentPosition]);
 
   return (
-    initialSlide && (
+    initialSlide != null && (
       <Swiper {...settings} initialSlide={initialSlide} className="h-full">
         {children}
         <CustomPagination />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- initialSlide가 추가되고 나서 현재 시간이 첫 페이지에 있다면 페이지 값이 0 (false)로 처리되는 문제 발견.

## 🎉 어떻게 해결했나요?
- 명시적으로 null 값인지 확인하는 로직으로 변경

### 📚 Attachment (Option)
- 목표가 4개 이상 없는 사용자는 목표를 볼 수 없습니다ㅠ0ㅠ  긴급긴급ㅠㅡㅠ

