### PR TITLE
bug: MapCard 레이아웃 이슈 해결

### DIFF
--- a/src/features/home/components/MapCardCollections/MapCard/MapCard.stories.tsx
+++ b/src/features/home/components/MapCardCollections/MapCard/MapCard.stories.tsx
@@ -22,3 +22,15 @@ export const Basic: Story = {
     position: { x: 'top-[20px]', y: 'left-[20px]' },
   },
 };
+
+export const Ellipsis: Story = {
+  args: {
+    ...Basic.args,
+    goal: {
+      id: 1,
+      stickerUrl: 'https://github.com/depromeet/amazing3-fe/assets/112946860/b266a620-a349-4f70-8236-be1612028a97',
+      deadline: '2024.01',
+      tagContent: '가나다라마바사',
+    },
+  },
+};

--- a/src/features/home/components/MapCardCollections/MapCard/MapCard.tsx
+++ b/src/features/home/components/MapCardCollections/MapCard/MapCard.tsx
@@ -27,12 +27,12 @@ export const MapCard = ({ goal, position }: MapCardProps) => {
           placeholder="blur"
           blurDataURL={blueDataURL.mapCard}
         />
-        <div className="flex gap-[4px] justify-center items-center">
+        <div className="flex max-w-[110px] gap-[4px] justify-center items-center">
           <Typography type="title5" className="text-blue-50">
             {deadline}
           </Typography>
           <VerticalBarIcon width="1" height="11" />
-          <Typography type="title5" className="text-blue-50">
+          <Typography type="title5" className="text-blue-50 text-ellipsis !whitespace-nowrap overflow-hidden">
             {tagContent}
           </Typography>
         </div>

--- a/src/features/home/components/MapCardCollections/MapCardLayout.tsx
+++ b/src/features/home/components/MapCardCollections/MapCardLayout.tsx
@@ -8,7 +8,7 @@ export interface MapCardLayoutProps {
 export const MapCardLayout = ({ position, cursor = 'cursor', children }: PropsWithChildren<MapCardLayoutProps>) => {
   return (
     <div
-      className={`absolute w-[130px] h-[130px] rounded-lg bg-white pt-[5px] pb-[6px] px-[16px] shadow-thumb ${position.x} ${position.y} overflow-hidden cursor-${cursor}`}
+      className={`flex flex-col items-center absolute w-[130px] h-[130px] rounded-lg bg-white p-[5px] shadow-thumb ${position.x} ${position.y} overflow-hidden cursor-${cursor}`}
     >
       {children}
     </div>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
<img width="153" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/9fb5f61a-ae0a-4f57-bb1f-8de6f49e7a62">

위 이미지처럼 텍스트 길이가 조금 길어질 경우 레이아웃 이슈 발견했습니다.

## 🎉 어떻게 해결했나요?
- 전체를 flex로 하여 가운데로 조정하는 방식으로 변경
- 상하좌우 padding으로 5px만을 주어, 최소한의 공백 적용

### 📚 Attachment (Option)

적용된 후 입니다 ^_^ㅠ
<img width="154" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/94631d44-1929-4478-9b51-e8899363bc48">


