### PR TITLE
bug: OAuth 이미지를 출력하기 위한 설정 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -43,7 +43,14 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com',
-        pathname: '/a/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'ssl.pstatic.net',
+      },
+      {
+        protocol: 'https',
+        hostname: 'k.kakaocdn.net',
       },
     ],
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,9 @@ export const metadata: Metadata = {
   },
   verification: {
     google: META.googleVerification,
+    other: {
+      'naver-site-verification': META.naverVerification,
+    },
   },
   twitter: {
     title: META.title,

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -16,9 +16,7 @@ export const META = {
     '응원',
   ],
   url: 'https://www.bandiboodi.com',
-  googleVerification: process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION,
+  googleVerification: 'I4Mm3zYYVzuUvDDVCZ_mfBSKCidmtlzFk-KEJROoFWg',
+  naverVerification: '33a87e5c4952dac5d89df1e8037868f9c5e049b3',
   ogImage: '/opengraph-image.png',
 } as const;
-
-// author: "BANDIBOODI | 반디부디"
-//


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
네이버 로그인과 관련된 설정을 추가했습니다.

## 🎉 어떻게 해결했나요?
- Naver 로그인 후 프로파일 이미지 출력 시 필요한 설정 추가
![스크린샷 2024-01-07 030801](https://github.com/depromeet/amazing3-fe/assets/34956359/ad1c37b1-ccdc-4e96-a647-aad6b2c4a32e)
- naver 검색을 통해 들어올 사용자를 위한 NAVER SEO 추가
- 불필요한 환경 변수 제거
   - 해당 값은 head tag에 그대로 출력되고 있기에 불필요하게 환경 변수로 관리할 필요가 없어 제거했습니다.

### 📚 Attachment (Option)
- 로그인을 위한 버튼은 도은 선생께서 작업하신 게 있어 dev에서 합친 후 테스트 해보겠습니다~

