### PR TITLE
feat: 마이페이지에 인생지도 공개 설정 라디오 버튼 그룹 추가

### DIFF
--- a/src/features/my/components/MyPageLayout.tsx
+++ b/src/features/my/components/MyPageLayout.tsx
@@ -6,14 +6,19 @@ import MyPageBody from './MyPageBody';
 import MypageHeader from './MyPageHeader';
 
 export const MyPageLayout = () => {
+  const nickname = '일이삼사오육칠팔구십';
+  const birth = '1999.08.23';
+  const username = 'bandiboodi';
+  const isPublic = true;
+
   // TODO: API 연결로 데이터 받아오기
 
   return (
     <div className="pt-5xs px-xs h-full flex flex-col">
       <MypageHeader />
-      <UserProfile />
+      <UserProfile nickname={nickname} username={username} birth={birth} />
       <MyPageBody />
-      <LifeMapPrivacySetting isPublic={true} />
+      <LifeMapPrivacySetting isPublic={isPublic} />
     </div>
   );
 };

--- a/src/features/my/components/MyPageLayout.tsx
+++ b/src/features/my/components/MyPageLayout.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import UserProfile from './userProfile/UserProfile';
+import { LifeMapPrivacySetting } from './lifeMapPrivacySetting';
 import MyPageBody from './MyPageBody';
 import MypageHeader from './MyPageHeader';
 
 export const MyPageLayout = () => {
+  // TODO: API 연결로 데이터 받아오기
+
   return (
     <div className="pt-5xs px-xs h-full flex flex-col">
       <MypageHeader />
       <UserProfile />
       <MyPageBody />
+      <LifeMapPrivacySetting isPublic={true} />
     </div>
   );
 };

--- a/src/features/my/components/lifeMapPrivacySetting/LifeMapPrivacySetting.tsx
+++ b/src/features/my/components/lifeMapPrivacySetting/LifeMapPrivacySetting.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Typography } from '@/components';
+
+import RadioButtonGroup from './RadioButtonGroup';
+
+interface LifeMapPrivacySettingProps {
+  isPublic: boolean;
+}
+
+export const LifeMapPrivacySetting = ({ isPublic }: LifeMapPrivacySettingProps) => {
+  const groupItems = [
+    { description: '전체보기', value: 'public', checked: isPublic },
+    { description: '나만보기', value: 'private', checked: !isPublic },
+  ];
+
+  return (
+    <div className="py-[15px] w-full flex justify-center">
+      <div className="w-[349px] h-[76px] flex gap-[36px] bg-white items-center justify-center rounded-lg shadow-[0_1.001px_40px_0_rgba(197,229,255,0.3)]">
+        <Typography type="caption1" className="text-gray-40">
+          인생지도 공개 범위
+        </Typography>
+        <RadioButtonGroup items={groupItems} />
+      </div>
+    </div>
+  );
+};

--- a/src/features/my/components/lifeMapPrivacySetting/RadioButton.tsx
+++ b/src/features/my/components/lifeMapPrivacySetting/RadioButton.tsx
@@ -1,0 +1,28 @@
+import type { ChangeEvent } from 'react';
+
+import { Typography } from '@/components';
+
+interface RadioButtonProps {
+  description: string;
+  value: string;
+  checked: boolean;
+  onChange: (value: string) => void;
+}
+
+const RadioButton = ({ description, value, checked, onChange }: RadioButtonProps) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <label className="flex gap-[7px] items-center">
+      {/* TODO: Radio Button 스타일 적용 필요 */}
+      <input className="w-[18px] h-[18px]" type="radio" value={value} checked={checked} onChange={handleChange} />
+      <Typography type="body3" className="text-gray-50">
+        {description}
+      </Typography>
+    </label>
+  );
+};
+
+export default RadioButton;

--- a/src/features/my/components/lifeMapPrivacySetting/RadioButtonGroup.tsx
+++ b/src/features/my/components/lifeMapPrivacySetting/RadioButtonGroup.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+import RadioButton from './RadioButton';
+
+interface RadioButtonGroupItemProps {
+  description: string;
+  value: string;
+  checked?: boolean;
+}
+
+interface RadioButtonGroupProps {
+  items: RadioButtonGroupItemProps[];
+}
+
+const RadioButtonGroup = ({ items }: RadioButtonGroupProps) => {
+  const initialSelectedItem = items.filter((item) => item.checked === true)[0] || items[0];
+  const [value, setValue] = useState<string>(initialSelectedItem.value);
+
+  const handleClickRadioButton = (value: string) => {
+    setValue(value);
+    // TODO: 공개 설정 수정시 API 요청 추가 및 요청 중 disabled 처리
+  };
+
+  return (
+    <div className="flex gap-3xs">
+      {items.map((item, index) => (
+        <RadioButton
+          key={index}
+          description={item.description}
+          value={item.value}
+          checked={item.value === value}
+          onChange={handleClickRadioButton}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default RadioButtonGroup;

--- a/src/features/my/components/lifeMapPrivacySetting/index.ts
+++ b/src/features/my/components/lifeMapPrivacySetting/index.ts
@@ -1,0 +1,1 @@
+export { LifeMapPrivacySetting } from './LifeMapPrivacySetting';

--- a/src/features/my/components/userProfile/UserProfile.tsx
+++ b/src/features/my/components/userProfile/UserProfile.tsx
@@ -10,8 +10,6 @@ const UserProfile = () => {
   const birth = '1999.08.23';
   const username = 'bandiboodi';
 
-  // TODO: API 연결로 데이터 받아오기
-
   return (
     <div className="mt-md flex flex-col gap-lg items-center justify-center">
       <div className="flex flex-col gap-5xs items-center">

--- a/src/features/my/components/userProfile/UserProfile.tsx
+++ b/src/features/my/components/userProfile/UserProfile.tsx
@@ -5,11 +5,13 @@ import { USER_PROFILE_IMAGE_SIZE } from '../../constants';
 import ProfileCard from './ProfileCard';
 import UserInfo from './UserInfo';
 
-const UserProfile = () => {
-  const nickname = '일이삼사오육칠팔구십';
-  const birth = '1999.08.23';
-  const username = 'bandiboodi';
+interface UserProfileProps {
+  nickname: string;
+  username: string;
+  birth: string;
+}
 
+const UserProfile = ({ nickname, username, birth }: UserProfileProps) => {
   return (
     <div className="mt-md flex flex-col gap-lg items-center justify-center">
       <div className="flex flex-col gap-5xs items-center">


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 마이페이지의 인생지도 공개 설정 라디오 버튼 그룹 추가

## 🎉 어떻게 해결했나요?
- RadioButton으로 이루어진 RadioButtonGroup을 구현

### 📚 Attachment (Option)
- 이후 API를 연결하고, 요청이 완료될 때까지 disabled 시키는 로직이 필요할 것 같아요!

