### PR TITLE
docs: 개인정보 처리 방침 문서 외부 링크 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
 
 import SplashBandiboodi from '@/assets/images/bandiboodi-splash.png';
 import LogoImage from '@/assets/images/logo.png';
 import PurpleBlurImage from '@/assets/images/purple-blur.png';
 import { Typography } from '@/components/atoms';
 import { LoginIconSet } from '@/components/molecules';
+import { PRIVACY_POLICY_URL } from '@/constants/externalURL';
 
 const SplashPage = () => {
   return (
@@ -29,14 +29,10 @@ const SplashPage = () => {
       <div className="absolute bottom-[10px] w-full flex flex-col gap-4xs items-center">
         <LoginIconSet google naver kakao />
         <Typography className="text-center text-gray-40" type="body3">
-          회원가입 시{' '}
-          <Link className=" underline" href="/">
-            서비스 이용약관
-          </Link>
-          과 <br />{' '}
-          <Link className="underline" href="/">
+          회원가입 시 서비스 이용약관과 <br />
+          <a className="underline" href={PRIVACY_POLICY_URL} target="_blank" rel="noopener noreferrer">
             개인정보 수집 및 이용
-          </Link>
+          </a>
           에 동의하게 됩니다.
         </Typography>
       </div>

--- a/src/constants/externalURL.ts
+++ b/src/constants/externalURL.ts
@@ -1,0 +1,1 @@
+export const PRIVACY_POLICY_URL = 'https://bandiboodi.notion.site/bandiboodi/e1f06aec04504955981c94e1cad9f2c3';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 카카오 Oauth 검수 과정에서 필요한 개인정보 처리 방침 링크 적용 

## 🎉 어떻게 해결했나요?
- a tag 적용하여 반영 (보안을 위해 noopener noreferrer 속성값 적용)
- notion 링크 공개를 위한 커스텀 도메인 변경 (`mammoth-smell-342.notion.site` -> `bandiboodi.notion.site`)

### 📚 Attachment (Option)
- 서비스 이용약관도 해야하는데... 일단 검수 결과 나오는 거 보고 서비스 이용약관 때문에 반려당하면 따로 만들어서 넣을게요 흑흑

