### PR TITLE
bug: 세부목표 페이지 세부 스타일 이슈 해결

### DIFF
--- a/src/components/atoms/toast/Toast.tsx
+++ b/src/components/atoms/toast/Toast.tsx
@@ -21,8 +21,8 @@ const toastIcon = {
   warning: <WarningIcon />,
 };
 
-const TOAST_DURATION = 3000;
-const ANIMATION_DURATION = 350;
+const TOAST_DURATION = 1500;
+const ANIMATION_DURATION = 200;
 
 export const Toast = ({ id, title, type = 'success' }: ToastProps) => {
   const [opacity, setOpacity] = useState('opacity-[0.2]');

--- a/src/components/atoms/toast/ToastProvider.tsx
+++ b/src/components/atoms/toast/ToastProvider.tsx
@@ -10,7 +10,7 @@ export const ToastProvider = () => {
 
   return (
     <Portal>
-      <div className={`fixed ${position} left-1/2 transform translate-x-[-50%]`}>
+      <div className={`fixed ${position} left-0 right-0 flex flex-col items-center z-50`}>
         {toasts.map((toast) => (
           <Toast key={toast.id} {...toast} />
         ))}

--- a/src/contexts/Providers.tsx
+++ b/src/contexts/Providers.tsx
@@ -15,10 +15,8 @@ const Providers = ({ children }: PropsWithChildren) => {
   return (
     <LazyMotion features={domAnimation}>
       <QueryClientProvider>
-        <OverlayProvider>
-          <ToastProvider />
-          {children}
-        </OverlayProvider>
+        <ToastProvider />
+        <OverlayProvider>{children}</OverlayProvider>
       </QueryClientProvider>
     </LazyMotion>
   );

--- a/src/features/goal/components/detail/task/Task.tsx
+++ b/src/features/goal/components/detail/task/Task.tsx
@@ -61,9 +61,12 @@ export const Task = ({ isDone = false, text, targetIds, onDoneClick }: TaskProps
         </button>
       </div>
       {isEditing ? (
-        <TaskEditInput value={editText} onChange={handleEditText} onBlur={handleUpdateDescription} />
+        <div className="flex flex-col w-full gap-7xs justify-center mt-7xs">
+          <TaskEditInput value={editText} onChange={handleEditText} onBlur={handleUpdateDescription} />
+          <div className="w-[90%] h-[1px] bg-blue-30" />
+        </div>
       ) : (
-        <div className="flex w-full justify-between">
+        <div className="flex w-full justify-between items-center">
           <Typography type="body3" className="text-gray-70">
             {text}
           </Typography>

--- a/src/features/goal/components/detail/task/TaskEditInput.tsx
+++ b/src/features/goal/components/detail/task/TaskEditInput.tsx
@@ -8,7 +8,7 @@ export const TaskEditInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HT
     return (
       <input
         ref={ref}
-        className="w-full mr-[20px] placeholder-gray-30 bg-transparent  disabled:cursor-not-allowed focus-visible:outline-none disabled:opacity-50 border border-t-0 border-x-0 border-b-blue-30 text-[14px] font-medium leading-[160%]"
+        className="w-full mr-[20px] placeholder-gray-30 bg-transparent disabled:cursor-not-allowed focus-visible:outline-none disabled:opacity-50 border-none text-[14px] font-medium"
         maxLength={TASK_MAX_LENGTH}
         {...props}
       />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?

### 안녕하세요.. 버그로 또 찾아왔습니다..

- 모바일에서 Toast의 메시지가 짧음에도 줄바꿈이 되는 이슈
- 모바일에서 세부목표 수정 input의 border-bottom 스타일 이슈
- Toast가 떠있는 시간이 조금 길다고 느껴짐 (개인적으로..

| Toast 이상 | Input 이상 |
|:--:|:--:|
| ![IMG_7903](https://github.com/depromeet/amazing3-fe/assets/112946860/9d804a16-c24b-4182-9506-5650ef4be6e5) | ![IMG_7904](https://github.com/depromeet/amazing3-fe/assets/112946860/2dff2586-c00c-4201-95ca-a37e16fa8384) |


## 🎉 어떻게 해결했나요?
- 스타일 수정..수정...

### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/112946860/4b309d38-3baa-42a7-862a-8039eaa8f2b5






