### PR TITLE
bug: 온보딩 페이지 레이아웃 이슈 해결

### DIFF
--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] max-h-[100dvh] bg-gradient2 pt-[10vh] pb-xs">{children}</div>;
+  return <div className="w-full h-[100dvh] bg-gradient2 pt-[5vh] pb-xs">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5dvh] bg-gradient2 pb-xs">{children}</div>;
+  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5dvh] bg-gradient2">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] max-h-[100dvh] bg-gradient2 pb-xs">{children}</div>;
+  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5vh] bg-gradient2 pb-xs">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] bg-gradient2 pt-[5vh] pb-xs">{children}</div>;
+  return <div className="w-full h-[100dvh] max-h-[100dvh] bg-gradient2 pb-xs">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5dvh] bg-gradient2">{children}</div>;
+  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5dvh] bg-gradient2 pb-xs">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5vh] bg-gradient2 pb-xs">{children}</div>;
+  return <div className="w-full h-[100dvh] max-h-[100dvh] pt-[5dvh] bg-gradient2 pb-xs">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const OnboardingLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] bg-gradient2 pt-[10vh] pb-xs">{children}</div>;
+  return <div className="w-full h-[100dvh] max-h-[100dvh] bg-gradient2 pt-[10vh] pb-xs">{children}</div>;
 };
 
 export default OnboardingLayout;

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -25,7 +25,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
 
 export const OnboardingBody = () => {
   return (
-    <div className="w-full h-full px-xs flex flex-col justify-between pb-xs">
+    <div className="w-full h-full px-xs flex flex-col justify-between">
       <div className="h-full">
         <OnboardingSwiper>
           {ONBOARDING_VALUES.map(({ title, sticker }, index) => (

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -14,23 +14,11 @@ import { OnboardingSwiper } from '../onboardingSwiper';
 
 const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
   {
-    title: (
-      <>
-        내가 걸어갈 길의 <br />
-        방향을 짚어가면서 <br />
-        목표와 계획을 세워보세요.
-      </>
-    ),
+    title: '내가 걸어갈 길의 \n 방향을 짚어가면서 \n 목표와 계획을 세워보세요.',
     sticker: <Image src={TargetSticker} width={268} height={268} alt="onboarding_image_2" priority />,
   },
   {
-    title: (
-      <>
-        한 조각씩 채우다 보면 <br />
-        나만의 인생지도가 <br />
-        완성될 거예요.
-      </>
-    ),
+    title: '한 조각씩 채우다 보면 \n 나만의 인생지도가 \n 완성될 거예요.',
     sticker: <Image src={MapSticker} width={268} height={268} alt="onboarding_image_3" priority />,
   },
 ];

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -25,8 +25,8 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
 
 export const OnboardingBody = () => {
   return (
-    <div className="w-full h-full px-xs flex flex-col">
-      <div className="h-full">
+    <div className="w-full h-full px-xs flex flex-col justify-between">
+      <div className="h-full flex items-center">
         <OnboardingSwiper>
           {ONBOARDING_VALUES.map(({ title, sticker }, index) => (
             <SwiperSlide key={index}>
@@ -35,11 +35,9 @@ export const OnboardingBody = () => {
           ))}
         </OnboardingSwiper>
       </div>
-      <div className="h-full flex flex-col-reverse">
-        <Link href={{ pathname: '/member/new/nickname' }}>
-          <Button className="flex-grow-1">시작하기</Button>
-        </Link>
-      </div>
+      <Link href={{ pathname: '/member/new/nickname' }}>
+        <Button className="flex-grow-1">시작하기</Button>
+      </Link>
     </div>
   );
 };

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -25,7 +25,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
 
 export const OnboardingBody = () => {
   return (
-    <div className="w-full h-full px-xs flex flex-col justify-between">
+    <div className="w-full h-full px-xs flex flex-col justify-between pb-xs">
       <div className="h-full">
         <OnboardingSwiper>
           {ONBOARDING_VALUES.map(({ title, sticker }, index) => (

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -25,7 +25,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
 
 export const OnboardingBody = () => {
   return (
-    <div className="w-full h-full px-xs flex flex-col justify-between">
+    <div className="w-full h-full px-xs flex flex-col">
       <div className="h-full">
         <OnboardingSwiper>
           {ONBOARDING_VALUES.map(({ title, sticker }, index) => (

--- a/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
+++ b/src/features/onboarding/components/onboardingBody/OnboardingBody.tsx
@@ -26,7 +26,7 @@ const ONBOARDING_VALUES: OnboardingLayoutProps[] = [
 export const OnboardingBody = () => {
   return (
     <div className="w-full h-full px-xs flex flex-col justify-between">
-      <div className="h-full flex items-center">
+      <div className="h-full">
         <OnboardingSwiper>
           {ONBOARDING_VALUES.map(({ title, sticker }, index) => (
             <SwiperSlide key={index}>

--- a/src/features/onboarding/components/onboardingLayout/onboardingLayout.tsx
+++ b/src/features/onboarding/components/onboardingLayout/onboardingLayout.tsx
@@ -9,7 +9,7 @@ export interface OnboardingLayoutProps {
 
 export const OnboardingLayout = ({ title, sticker }: OnboardingLayoutProps) => {
   return (
-    <section className="w-full h-[100%] flex flex-col gap-2xs items-center">
+    <section className="w-full h-full flex justify-center">
       <div className="w-[80%]">
         <Typography type="heading1" className="text-blue-50 mr-auto">
           {title}

--- a/src/features/onboarding/components/onboardingSwiper/OnboardingSwiper.tsx
+++ b/src/features/onboarding/components/onboardingSwiper/OnboardingSwiper.tsx
@@ -15,7 +15,7 @@ const settings = {
 
 export const OnboardingSwiper = ({ children }: PropsWithChildren) => {
   return (
-    <Swiper {...settings} className="w-full h-[80%]">
+    <Swiper {...settings} className="w-full h-[95%]">
       {children}
     </Swiper>
   );

--- a/src/features/onboarding/components/onboardingSwiper/OnboardingSwiper.tsx
+++ b/src/features/onboarding/components/onboardingSwiper/OnboardingSwiper.tsx
@@ -15,7 +15,7 @@ const settings = {
 
 export const OnboardingSwiper = ({ children }: PropsWithChildren) => {
   return (
-    <Swiper {...settings} className="w-full">
+    <Swiper {...settings} className="w-full h-[80%]">
       {children}
     </Swiper>
   );


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- safari(모바일)에서 온보딩 페이지 레이아웃 이슈

<img width="229" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/815739bb-0f5d-407a-970c-d5dcafbd0b7d">


## 🎉 어떻게 해결했나요?

- 스타일 일부 수정했습니다.....~~

| safari | chrome |
|:--:|:--:|
| <img width="229" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/f591c913-361b-44bf-a211-cc4802898987"> | <img width="229" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/62e0be03-9d7e-48f7-82e4-80c1b69e0dfe"> | 

사파리는...죽어도 padding-bottom이 안 들어가긴 해서 그나마 이쁘게 보이는 걸로 마무리합니다...~~~!
### 📚 Attachment (Option)
- N/A
