### PR TITLE
fix: ios에서 인생지도 다운로드 안되는 이슈 해결

### DIFF
--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -2,8 +2,7 @@ import { type RefObject, useState } from 'react';
 import { domToJpeg } from 'modern-screenshot';
 
 import { GOAL_COUNT_PER_PAGE } from '@/features/home/constants';
-import { downloadFile, shareImage } from '@/utils/image';
-import { isIos } from '@/utils/userAgent';
+import { downloadFile } from '@/utils/image';
 
 import { backgroundImage } from '../../styles/theme';
 
@@ -61,8 +60,8 @@ export const useDownloadImage = ({ type, imageRef }: DownloadImageOption) => {
       const imageUrl = await domToJpeg(image, imageOption);
 
       const IMAGE_FILE_NAME = '별이되고_싶은_반디부디의_인생지도';
-      if (isIos()) shareImage(imageUrl, IMAGE_FILE_NAME);
-      else downloadFile(imageUrl, IMAGE_FILE_NAME);
+
+      downloadFile(imageUrl, IMAGE_FILE_NAME);
     } catch (error) {
       // TODO: 이미지 다운로드 실패 시, 추가 에러 처리 필요
       console.error(error);

--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -1,4 +1,5 @@
 import { type RefObject, useState } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { domToJpeg } from 'modern-screenshot';
 
 import { GOAL_COUNT_PER_PAGE } from '@/features/home/constants';
@@ -7,6 +8,7 @@ import { downloadFile } from '@/utils/image';
 import { backgroundImage } from '../../styles/theme';
 
 import { useGetGoals } from './reactQuery/goal';
+import { useToast } from './useToast';
 
 interface DownloadImageOption {
   type: 'ALL' | 'CURRENT';
@@ -25,6 +27,7 @@ export const useDownloadImage = ({ type, imageRef }: DownloadImageOption) => {
   const [isDownloading, setIsDownloading] = useState(false);
 
   const { data: goalsData } = useGetGoals();
+  const toast = useToast();
 
   const getPageCount = () => Math.floor((goalsData?.goalsCount || 1) / GOAL_COUNT_PER_PAGE) + 1;
 
@@ -63,8 +66,8 @@ export const useDownloadImage = ({ type, imageRef }: DownloadImageOption) => {
 
       downloadFile(imageUrl, IMAGE_FILE_NAME);
     } catch (error) {
-      // TODO: 이미지 다운로드 실패 시, 추가 에러 처리 필요
-      console.error(error);
+      toast.warning('인생지도 다운로드에 실패했어요.');
+      Sentry.captureException(error);
     } finally {
       setIsDownloading(false);
     }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- ios에서 이미지 다운로드 안되는 이슈 해결

## 🎉 어떻게 해결했나요?
- ios에서 이미지 다운로드 시 공유 기능 -> 파일 다운로드로 수정

https://github.com/depromeet/amazing3-fe/assets/80238096/7993847c-aed0-41dc-b6fe-8e381d4eb59f

