### PR TITLE
feat: 로그인 안한 사용자가 상세 목표 조회 시 로그인 버튼 시트 출력

### DIFF
--- a/src/features/home/components/MapCardCollections/MapCard/MapCard.tsx
+++ b/src/features/home/components/MapCardCollections/MapCard/MapCard.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useOverlay } from '@toss/use-overlay';
 import { useAtomValue } from 'jotai';
 
@@ -18,19 +18,20 @@ export interface MapCardProps extends MapCardLayoutProps {
 
 export const MapCard = ({ goal, position }: MapCardProps) => {
   const { id, stickerUrl, deadline, tagContent } = goal;
+  const router = useRouter();
   const isLogin = useAtomValue(isLoginAtom);
-  console.log(isLogin);
-  const goalDetailPath = isLogin ? `/goal/detail/${id}` : '';
   const { open } = useOverlay();
 
   const handleMapCardClick = () => {
-    if (isLogin) return;
-
-    open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
+    if (isLogin) {
+      router.push(`/goal/detail/${id}`);
+    } else {
+      open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
+    }
   };
 
   return (
-    <Link href={{ pathname: goalDetailPath }} onClick={handleMapCardClick}>
+    <button onClick={handleMapCardClick}>
       <MapCardLayout position={position}>
         <Image
           src={stickerUrl}
@@ -51,6 +52,6 @@ export const MapCard = ({ goal, position }: MapCardProps) => {
           </Typography>
         </div>
       </MapCardLayout>
-    </Link>
+    </button>
   );
 };

--- a/src/features/home/components/MapCardCollections/MapCard/MapCard.tsx
+++ b/src/features/home/components/MapCardCollections/MapCard/MapCard.tsx
@@ -1,11 +1,15 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { useOverlay } from '@toss/use-overlay';
+import { useAtomValue } from 'jotai';
 
 import VerticalBarIcon from '@/assets/icons/vertical-bar.svg';
 import { Typography } from '@/components';
 import { blueDataURL } from '@/constants';
+import { isLoginAtom } from '@/features/auth/atom';
 import type { GoalProps } from '@/hooks/reactQuery/goal/useGetGoals';
 
+import { LoginBottomSheet } from '../../loginBottomSheet';
 import { MapCardLayout, type MapCardLayoutProps } from '../MapCardLayout';
 
 export interface MapCardProps extends MapCardLayoutProps {
@@ -14,9 +18,19 @@ export interface MapCardProps extends MapCardLayoutProps {
 
 export const MapCard = ({ goal, position }: MapCardProps) => {
   const { id, stickerUrl, deadline, tagContent } = goal;
+  const isLogin = useAtomValue(isLoginAtom);
+  console.log(isLogin);
+  const goalDetailPath = isLogin ? `/goal/detail/${id}` : '';
+  const { open } = useOverlay();
+
+  const handleMapCardClick = () => {
+    if (isLogin) return;
+
+    open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
+  };
 
   return (
-    <Link href={{ pathname: `/goal/detail/${id}` }}>
+    <Link href={{ pathname: goalDetailPath }} onClick={handleMapCardClick}>
       <MapCardLayout position={position}>
         <Image
           src={stickerUrl}

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -119,17 +119,15 @@ export const LifeMapContent = ({ goalsData, memberData, downloadSectionRef, isPu
             <MapSwiper currentPage={currentPage}>
               {participatedGoalsArray?.map((goals, page) => (
                 <SwiperSlide key={`swiper-goal-${page}`}>
-                  <div className={isPublic ? `pointer-events-none` : ''}>
-                    {!(page % 2) ? (
-                      <MapCardPositioner type="A" goals={goals} isFirst={page === 0} isLast={page === LAST_PAGE - 1} />
-                    ) : (
-                      <MapCardPositioner type="B" goals={goals} isLast={page === LAST_PAGE - 1} />
-                    )}
-                    {/** 현재 위치에 별 위치 시키기 위해 1) 현재 날짜가 포함된 페이지를 찾아서, 2) 포지션 위치에 별을 출력함. */}
-                    {positionState.positionPage === page && positionState.position && (
-                      <CurrentPositionCover currentPosition={positionState.position} />
-                    )}
-                  </div>
+                  {!(page % 2) ? (
+                    <MapCardPositioner type="A" goals={goals} isFirst={page === 0} isLast={page === LAST_PAGE - 1} />
+                  ) : (
+                    <MapCardPositioner type="B" goals={goals} isLast={page === LAST_PAGE - 1} />
+                  )}
+                  {/** 현재 위치에 별 위치 시키기 위해 1) 현재 날짜가 포함된 페이지를 찾아서, 2) 포지션 위치에 별을 출력함. */}
+                  {positionState.positionPage === page && positionState.position && (
+                    <CurrentPositionCover currentPosition={positionState.position} />
+                  )}
                 </SwiperSlide>
               ))}
             </MapSwiper>

--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -18,7 +18,7 @@ export const PublicLifeMap = ({ username }: { username: string }) => {
       <LifeMapContent isPublic goalsData={publicGoals} memberData={publicGoals?.user} />
       <div className="px-xs pt-5xs mt-[18px] w-full">
         <Link href={{ pathname: myHomePath }} className="w-full">
-          <Button>내 지도로 돌아가기</Button>
+          <Button>{memberData?.username ? '내 지도로 돌아가기' : '로그인하기'}</Button>
         </Link>
       </div>
     </>

--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -1,11 +1,26 @@
 'use client';
 
+import Link from 'next/link';
+
+import { Button } from '@/components/atoms';
+import { useGetMemberData } from '@/hooks/reactQuery/auth';
 import { useGetPublicGoals } from '@/hooks/reactQuery/goal/useGetPublicGoals';
 
 import { LifeMapContent } from './LifeMapContent';
 
 export const PublicLifeMap = ({ username }: { username: string }) => {
   const { data: publicGoals } = useGetPublicGoals({ username });
+  const { data: memberData } = useGetMemberData();
+  const myHomePath = memberData?.username ? `/home/${memberData.username}` : '/';
 
-  return <LifeMapContent isPublic goalsData={publicGoals} memberData={publicGoals?.user} />;
+  return (
+    <>
+      <LifeMapContent isPublic goalsData={publicGoals} memberData={publicGoals?.user} />
+      <div className="px-xs pt-5xs mt-[18px] w-full">
+        <Link href={{ pathname: myHomePath }} className="w-full">
+          <Button>내 지도로 돌아가기</Button>
+        </Link>
+      </div>
+    </>
+  );
 };

--- a/src/features/home/components/loginBottomSheet/LoginBottomSheet.tsx
+++ b/src/features/home/components/loginBottomSheet/LoginBottomSheet.tsx
@@ -22,7 +22,7 @@ export const LoginBottomSheet = ({ open, onClose }: LoginBottomSheetProps) => {
         </div>
         <div className="absolute bottom-0 w-full h-[237px] pt-[100px] bg-gradient7 flex flex-col gap-4xs items-center">
           <ToolTip title="3초만에 시작하기" />
-          <LoginIconSet google />
+          <LoginIconSet google naver kakao />
         </div>
         <div className="absolute top-[127px]">
           <Image src={BandiBoodi3DImage} width={220} alt="bandiboodi" />

--- a/src/features/my/components/logoutBottomSheet/Footer.tsx
+++ b/src/features/my/components/logoutBottomSheet/Footer.tsx
@@ -1,7 +1,9 @@
 import { useRouter } from 'next/navigation';
+import { useSetAtom } from 'jotai';
 import Cookies from 'js-cookie';
 
 import { Button } from '@/components/atoms';
+import { isLoginAtom } from '@/features/auth/atom';
 
 interface FooterProps {
   onClose: VoidFunction;
@@ -9,9 +11,11 @@ interface FooterProps {
 
 const Footer = ({ onClose }: FooterProps) => {
   const router = useRouter();
+  const setIsLogin = useSetAtom(isLoginAtom);
 
   const handleClickLogout = () => {
     Cookies.remove('accessToken');
+    setIsLogin(false);
     router.push('/');
   };
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [로그인 시 남의 목표 카드 클릭 시 로그인 bottom sheet 출력](https://www.notion.so/depromeet/bottom-sheet-1b9f8e10c130438a99ffa29dcced60f0?pvs=4)
- [남의 홈 화면에서 내 홈으로 가는 버튼 필요](https://www.notion.so/depromeet/9c0441b9ab2844269899d4e5638a8112?pvs=4)

## 🎉 어떻게 해결했나요?
- 지도 클릭 시 클릭 이벤트 추가 (로그인 안했을 때 로그인 bottom sheet 띄우기)
- public 지도 접근 시 하단에 `내 지도로 돌아가기` 버튼 생성
- 로그아웃 시 isLoginAtom 값 false로 변경


https://github.com/depromeet/amazing3-fe/assets/34956359/594bb9bc-f7c9-4704-923d-5d8e0c869fad



### 📚 Attachment (Option)
- 남의 목표 상세보기 화면에서 상세목표 등록하기, 완료표시 등 수정 기능 사용 못하도록 수정 필요 (https://www.notion.so/depromeet/9de0c9b05d1c49d998844728eae0e166?pvs=4)

