### PR TITLE
feat: 마이페이지 수정 기능 반영과 관련 프로파일 이미지 선택 필드 추가

### DIFF
--- a/src/components/atoms/toast/Toast.tsx
+++ b/src/components/atoms/toast/Toast.tsx
@@ -21,7 +21,7 @@ const toastIcon = {
   warning: <WarningIcon />,
 };
 
-const TOAST_DURATION = 1500;
+const TOAST_DURATION = 2000;
 const ANIMATION_DURATION = 200;
 
 export const Toast = ({ id, title, type = 'success' }: ToastProps) => {

--- a/src/features/member/components/new/NicknameInputForm.tsx
+++ b/src/features/member/components/new/NicknameInputForm.tsx
@@ -17,7 +17,7 @@ import FormLayout from './FormLayout';
 
 export const NicknameInputForm = () => {
   const isMounted = useIsMounted();
-  const { register, control, setValue } = useFormContext<NewMemberFormValues>();
+  const { register, control } = useFormContext<NewMemberFormValues>();
   const { field } = useController({ name: 'nickname', control });
   const { onChange, value } = field;
   const { data: memberData } = useGetMemberData();
@@ -31,10 +31,9 @@ export const NicknameInputForm = () => {
         router.push(`/home/${memberData?.username}`);
       } else {
         setIsReady(true);
-        setValue('username', memberData.username);
       }
     }
-  }, [memberData, router, setValue]);
+  }, [memberData, router]);
 
   const isInvalidInput = () => (value ? value.length === 0 : true);
 

--- a/src/features/member/contexts/NewMemberFormProvider.tsx
+++ b/src/features/member/contexts/NewMemberFormProvider.tsx
@@ -23,8 +23,8 @@ const NewMemberFormProvider = ({ children }: PropsWithChildren) => {
   const methods = useForm<NewMemberFormValues>();
 
   const submit = (formData: NewMemberFormValues) => {
-    const { nickname, birth, username } = formData;
-    if (!nickname || !birth || !username) return;
+    const { nickname, birth } = formData;
+    if (!nickname || !birth) return;
 
     // Convert birth from "YYYY.MM.DD" to "YYYY-MM-DD"
     // TODO: 서버에서 YYYY.MM.DD 형식을 지원하면 이 부분 삭제

--- a/src/features/member/types/form.ts
+++ b/src/features/member/types/form.ts
@@ -1,7 +1,6 @@
 export interface NewMemberFormValues {
   nickname: string;
   birth: string;
-  username: string;
 }
 
 export interface MemberProps {

--- a/src/features/my/components/update/ProfileImageBottomSheet.tsx
+++ b/src/features/my/components/update/ProfileImageBottomSheet.tsx
@@ -1,0 +1,50 @@
+import type { Control } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
+import Image from 'next/image';
+
+import { BottomSheet } from '@/components/atoms';
+import { useGetDefaultProfileImages } from '@/hooks/reactQuery/profile';
+
+import type { UpdateMemberDataFormValues } from '../../types';
+
+interface ProfileImageBottomSheetProps {
+  open: boolean;
+  onClose: VoidFunction;
+  control: Control<UpdateMemberDataFormValues, unknown>;
+}
+
+const ProfileImageBottomSheet = ({ open, onClose, control }: ProfileImageBottomSheetProps) => {
+  const { data: profileImageData } = useGetDefaultProfileImages();
+
+  return (
+    <BottomSheet open={open} onDismiss={onClose} fixedMaxHeight={540}>
+      <div className="p-3xs">
+        <Controller
+          name="image"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <div className="grid grid-cols-3 gap-3xs">
+              {profileImageData?.map(({ id, name, url }) => (
+                <button
+                  key={id}
+                  className="flex flex-col items-center"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    onChange(url);
+                    onClose();
+                  }}
+                >
+                  <div className={`p-5xs rounded-lg ${value === url ? 'bg-blue-10' : ''}`}>
+                    <Image src={url} alt={name} width={150} height={150} priority />
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        />
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default ProfileImageBottomSheet;

--- a/src/features/my/components/update/ProfileImageButton.tsx
+++ b/src/features/my/components/update/ProfileImageButton.tsx
@@ -1,18 +1,37 @@
+import type { Control } from 'react-hook-form';
+import { useOverlay } from '@toss/use-overlay';
+
 import CameraIcon from '@/assets/icons/camera-icon.svg';
 import { Avatar } from '@/components';
 
+import type { UpdateMemberDataFormValues } from '../../types';
+
+import ProfileImageBottomSheet from './ProfileImageBottomSheet';
+
 interface ProfileImageButtonProps {
   image: string;
+  control: Control<UpdateMemberDataFormValues, unknown>;
 }
 
-const ProfileImageButton = ({ image }: ProfileImageButtonProps) => {
+const ProfileImageButton = ({ image, control }: ProfileImageButtonProps) => {
+  const { open } = useOverlay();
+
+  const handleOpenBottomSheet = () => {
+    open(({ isOpen, close }) => <ProfileImageBottomSheet open={isOpen} onClose={close} control={control} />);
+  };
   return (
-    <button className="relative">
+    <div className="relative">
       <Avatar size={151} profileImage={image} />
-      <div className="p-[6px] rounded-xl absolute right-0 bottom-0 bg-white drop-shadow-[0_0_7.9px_rgba(0,88,255,0.1)]">
+      <button
+        onClick={(e) => {
+          e.preventDefault();
+          handleOpenBottomSheet();
+        }}
+        className="p-[6px] rounded-xl absolute right-0 bottom-0 bg-white drop-shadow-[0_0_7.9px_rgba(0,88,255,0.1)]"
+      >
         <CameraIcon />
-      </div>
-    </button>
+      </button>
+    </div>
   );
 };
 

--- a/src/features/my/components/update/ProfileImageButton.tsx
+++ b/src/features/my/components/update/ProfileImageButton.tsx
@@ -20,18 +20,18 @@ const ProfileImageButton = ({ image, control }: ProfileImageButtonProps) => {
     open(({ isOpen, close }) => <ProfileImageBottomSheet open={isOpen} onClose={close} control={control} />);
   };
   return (
-    <div className="relative">
+    <button
+      className="relative"
+      onClick={(e) => {
+        e.preventDefault();
+        handleOpenBottomSheet();
+      }}
+    >
       <Avatar size={151} profileImage={image} />
-      <button
-        onClick={(e) => {
-          e.preventDefault();
-          handleOpenBottomSheet();
-        }}
-        className="p-[6px] rounded-xl absolute right-0 bottom-0 bg-white drop-shadow-[0_0_7.9px_rgba(0,88,255,0.1)]"
-      >
+      <div className="p-[6px] rounded-xl absolute right-0 bottom-0 bg-white drop-shadow-[0_0_7.9px_rgba(0,88,255,0.1)]">
         <CameraIcon />
-      </button>
-    </div>
+      </div>
+    </button>
   );
 };
 

--- a/src/features/my/components/update/UpdateForm.tsx
+++ b/src/features/my/components/update/UpdateForm.tsx
@@ -19,6 +19,7 @@ export const UpdateForm = () => {
   const { data: memberData } = useGetMemberData();
 
   const { register, setValue, control } = useFormContext<UpdateMemberDataFormValues>();
+  const { field: imageField } = useController({ name: 'image', control });
   const { field: nicknameField } = useController({ name: 'nickname', control });
   const { field: birthField } = useController({ name: 'birth', control });
   const { field: usernameField } = useController({ name: 'username', control });
@@ -28,6 +29,7 @@ export const UpdateForm = () => {
   useEffect(() => {
     if (!memberData) return;
 
+    setValue('image', memberData.image);
     setValue('nickname', memberData.nickname);
     setValue('username', memberData.username);
     setValue('birth', memberData.birth);
@@ -36,6 +38,7 @@ export const UpdateForm = () => {
   useEffect(() => {
     if (
       !memberData ||
+      imageField.value === undefined ||
       nicknameField.value === undefined ||
       usernameField.value === undefined ||
       birthField.value === undefined
@@ -43,15 +46,19 @@ export const UpdateForm = () => {
       return;
 
     const isNotModified =
+      memberData.image === imageField.value &&
       memberData.nickname === nicknameField.value &&
       memberData.username === usernameField.value &&
       memberData.birth === birthField.value;
 
     const isNotFilled =
-      nicknameField.value.length === 0 || usernameField.value.length === 0 || birthField.value.length !== 10;
+      imageField.value.length === 0 ||
+      nicknameField.value.length === 0 ||
+      usernameField.value.length === 0 ||
+      birthField.value.length !== 10;
 
     setIsDisabledSubmit(isNotFilled || isNotModified);
-  }, [memberData, nicknameField, birthField, usernameField]);
+  }, [memberData, imageField, nicknameField, birthField, usernameField]);
 
   return (
     <FormLayout
@@ -60,7 +67,7 @@ export const UpdateForm = () => {
         memberData && (
           <div className="pb-xl flex flex-col">
             <div className="flex justify-center">
-              <ProfileImageButton image={memberData.image} />
+              <ProfileImageButton image={imageField.value} control={control} />
             </div>
             <div className="pt-[26px] flex flex-col gap-3xs">
               <div {...register('nickname')}>
@@ -75,7 +82,7 @@ export const UpdateForm = () => {
               <div {...register('birth')}>
                 <DateInput
                   labelName="생년월일"
-                  intitalValue={memberData.birth}
+                  intitalValue={memberData.birth.replace(/\-/g, '.')}
                   maxLength={MAX_DATE_LENGTH_UNTIL_DAY}
                   onChange={birthField.onChange}
                 />

--- a/src/features/my/components/withdrawBottomSheet/Footer.tsx
+++ b/src/features/my/components/withdrawBottomSheet/Footer.tsx
@@ -1,11 +1,9 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAtomValue } from 'jotai';
 import Cookies from 'js-cookie';
 
 import { Button } from '@/components/atoms';
 import { Spinner } from '@/components/atoms/spinner';
-import { isLoginAtom } from '@/features/auth/atom';
 import { useDeleteMemberData } from '@/hooks/reactQuery/auth/useDeleteMemberData';
 
 interface FooterProps {
@@ -15,7 +13,6 @@ interface FooterProps {
 const Footer = ({ onClose }: FooterProps) => {
   const router = useRouter();
   const { mutate, isSuccess, isPending } = useDeleteMemberData();
-  const isLogin = useAtomValue(isLoginAtom);
 
   useEffect(() => {
     if (isSuccess) {

--- a/src/features/my/components/withdrawBottomSheet/Footer.tsx
+++ b/src/features/my/components/withdrawBottomSheet/Footer.tsx
@@ -1,21 +1,46 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAtomValue } from 'jotai';
+import Cookies from 'js-cookie';
+
 import { Button } from '@/components/atoms';
+import { Spinner } from '@/components/atoms/spinner';
+import { isLoginAtom } from '@/features/auth/atom';
+import { useDeleteMemberData } from '@/hooks/reactQuery/auth/useDeleteMemberData';
 
 interface FooterProps {
   onClose: VoidFunction;
 }
 
 const Footer = ({ onClose }: FooterProps) => {
+  const router = useRouter();
+  const { mutate, isSuccess, isPending } = useDeleteMemberData();
+  const isLogin = useAtomValue(isLoginAtom);
+
+  useEffect(() => {
+    if (isSuccess) {
+      Cookies.remove('accessToken');
+      router.push('/');
+    }
+  }, [isSuccess, router]);
+
   const handleClickWithdraw = () => {
-    // TODO: 회원 탈퇴 요청
-    alert('준비중인 기능입니다!');
+    if (process.env.NODE_ENV !== 'development') {
+      alert('준비중인 기능입니다!');
+      return;
+    }
+
+    // TODO: 서버에서 해당 기능 개발 후 live 환경에 회원 탈퇴 기능 반영
+    mutate();
   };
+
   return (
     <div className="flex gap-5xs mb-5xs">
       <Button variant="tertiary" onClick={onClose}>
         취소
       </Button>
-      <Button variant="issue" onClick={handleClickWithdraw}>
-        탈퇴하기
+      <Button variant="issue" onClick={handleClickWithdraw} disabled={isPending}>
+        {isPending ? <Spinner /> : '탈퇴하기'}
       </Button>
     </div>
   );

--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -3,7 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { DevTool } from '@hookform/devtools';
 
-import { useCreateMemberData } from '@/hooks/reactQuery/auth';
+import { useUpdateMemberData } from '@/hooks/reactQuery/auth';
 import { useIsMounted } from '@/hooks/useIsMounted';
 
 import type { UpdateMemberDataFormValues } from '../types';
@@ -11,7 +11,7 @@ import type { UpdateMemberDataFormValues } from '../types';
 const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
   const router = useRouter();
   const isMounted = useIsMounted();
-  const { mutate, isSuccess } = useCreateMemberData();
+  const { mutate, isSuccess } = useUpdateMemberData();
 
   useEffect(() => {
     if (isSuccess) {

--- a/src/features/my/types/form.ts
+++ b/src/features/my/types/form.ts
@@ -1,4 +1,5 @@
 export interface UpdateMemberDataFormValues {
+  image: string;
   nickname: string;
   username: string;
   birth: string;

--- a/src/hooks/reactQuery/auth/index.ts
+++ b/src/hooks/reactQuery/auth/index.ts
@@ -1,3 +1,4 @@
 export { useCreateMemberData } from './useCreateMemberData';
+export { useDeleteMemberData } from './useDeleteMemberData';
 export { useGetMemberData } from './useGetMemberData';
 export { useUpdateMemberData } from './useUpdateMemberData';

--- a/src/hooks/reactQuery/auth/index.ts
+++ b/src/hooks/reactQuery/auth/index.ts
@@ -1,2 +1,3 @@
 export { useCreateMemberData } from './useCreateMemberData';
 export { useGetMemberData } from './useGetMemberData';
+export { useUpdateMemberData } from './useUpdateMemberData';

--- a/src/hooks/reactQuery/auth/useCreateMemberData.ts
+++ b/src/hooks/reactQuery/auth/useCreateMemberData.ts
@@ -4,7 +4,6 @@ import { api } from '@/apis';
 
 export interface MemberRequest {
   nickname: string;
-  username: string;
   birth: string;
 }
 

--- a/src/hooks/reactQuery/auth/useDeleteMemberData.ts
+++ b/src/hooks/reactQuery/auth/useDeleteMemberData.ts
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/apis';
+
+export const useDeleteMemberData = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => api.delete('/my'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['memberData'] }),
+  });
+};

--- a/src/hooks/reactQuery/auth/useUpdateMemberData.ts
+++ b/src/hooks/reactQuery/auth/useUpdateMemberData.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/apis';
+import { useToast } from '@/hooks/useToast';
+
+export interface UpdateMemberRequest {
+  nickname: string;
+  birth: string;
+  username: string;
+  image: string;
+}
+
+interface ResponseError extends Error {
+  status?: number;
+}
+
+export const useUpdateMemberData = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: (data: UpdateMemberRequest) => api.put('/users', data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['memberData'] }),
+    onError: (error: ResponseError) => {
+      const errorMessage = error.status === 409 ? '이미 존재하는 아이디에요.' : '다시 시도해주세요.';
+      toast.warning(`회원정보 수정에 실패했어요. ${errorMessage}`);
+    },
+  });
+};

--- a/src/hooks/reactQuery/profile/index.ts
+++ b/src/hooks/reactQuery/profile/index.ts
@@ -1,0 +1,1 @@
+export { useGetDefaultProfileImages } from './useGetDefaultProfileImages';

--- a/src/hooks/reactQuery/profile/useGetDefaultProfileImages.ts
+++ b/src/hooks/reactQuery/profile/useGetDefaultProfileImages.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/apis';
+
+type ProfileImagesResponse = Array<{
+  id: number;
+  name: string;
+  url: string;
+}>;
+
+export const useGetDefaultProfileImages = () => {
+  return useQuery<ProfileImagesResponse>({
+    queryKey: ['profileImages'],
+    queryFn: () => api.get<ProfileImagesResponse>('/profile/default'),
+  });
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [마이페이지 수정 기능 온보딩과 분리 필요 + 프로파일 이미지 선택 필드 추가](https://www.notion.so/depromeet/8a67704e442c43fba76710e1ac549515?pvs=4)

## 🎉 어떻게 해결했나요?
- 기존 put /my 로직을 api에 맞게 수정
- 온보딩 테스트를 위해 dev인 경우 사용할 수 있는 탈퇴 기능 개발
- profile image를 포함한 put /users api 적용
   - get /profile/default api를 통해 가져온 프로파일 이미지를 bottom sheet에 출력하고, 이미지 하나 선택 시 프로파일에 보여주도록 기능 개발.
   - update 수행 시 409 에러 발생 시 중복된 username이 존재한다는 메세지 toast로 출력
- toast 출력 시간이 너무 짧아 조금 늘림.

https://github.com/depromeet/amazing3-fe/assets/34956359/4edc331d-9c4d-45a1-9f0b-e1ed41f541ba




### 📚 Attachment (Option)
- TODO: update 수행하는 동안 '저장' 버튼 disable 시킬 방법 찾기
