### PR TITLE
bug: 생년월일로 미래를 입력할 경우 disabled & toast 처리

### DIFF
--- a/src/features/member/components/new/BirthInputForm.tsx
+++ b/src/features/member/components/new/BirthInputForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 
@@ -8,25 +8,42 @@ import BirthIcon from '@/assets/icons/birth-icon.svg';
 import { Button } from '@/components';
 import { MAX_DATE_LENGTH_UNTIL_DAY } from '@/constants';
 import { DateInput } from '@/features/goal/components/new/DateInput';
+import { useToast } from '@/hooks/useToast';
 
 import type { NewMemberFormValues } from '../../types';
 
 import FormLayout from './FormLayout';
 
 export const BirthInputForm = () => {
+  const toast = useToast();
   const router = useRouter();
   const { register, getValues, control } = useFormContext<NewMemberFormValues>();
   const { field } = useController({ name: 'birth', control });
   const { onChange, value } = field;
   const { nickname } = getValues();
-
-  const isInvalidInput = () => (value ? value.length !== MAX_DATE_LENGTH_UNTIL_DAY : true);
+  const [isValidBirth, setIsValidBirth] = useState(false);
 
   useEffect(() => {
     if (!nickname) {
       router.push('/member/new/nickname');
     }
   }, []);
+
+  useEffect(() => {
+    if (value) {
+      if (value.length === MAX_DATE_LENGTH_UNTIL_DAY) {
+        const today = new Date();
+        const inputValue = new Date(value);
+
+        if (today < inputValue) {
+          toast.warning('올바른 생년월일을 입력해주세요.');
+          setIsValidBirth(false);
+          return;
+        }
+      }
+      setIsValidBirth(value.length === MAX_DATE_LENGTH_UNTIL_DAY);
+    }
+  }, [value]);
 
   return (
     <FormLayout
@@ -39,7 +56,7 @@ export const BirthInputForm = () => {
           <div {...register('birth')}>
             <DateInput maxLength={MAX_DATE_LENGTH_UNTIL_DAY} onChange={onChange} />
           </div>
-          <Button type="submit" disabled={isInvalidInput()}>
+          <Button type="submit" disabled={!isValidBirth}>
             완료
           </Button>
         </div>

--- a/src/features/member/components/new/BirthInputForm.tsx
+++ b/src/features/member/components/new/BirthInputForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 
@@ -8,42 +8,25 @@ import BirthIcon from '@/assets/icons/birth-icon.svg';
 import { Button } from '@/components';
 import { MAX_DATE_LENGTH_UNTIL_DAY } from '@/constants';
 import { DateInput } from '@/features/goal/components/new/DateInput';
-import { useToast } from '@/hooks/useToast';
+import { useValidBirth } from '@/hooks/useValidBirth';
 
 import type { NewMemberFormValues } from '../../types';
 
 import FormLayout from './FormLayout';
 
 export const BirthInputForm = () => {
-  const toast = useToast();
   const router = useRouter();
   const { register, getValues, control } = useFormContext<NewMemberFormValues>();
   const { field } = useController({ name: 'birth', control });
   const { onChange, value } = field;
+  const isValidBirth = useValidBirth(value);
   const { nickname } = getValues();
-  const [isValidBirth, setIsValidBirth] = useState(false);
 
   useEffect(() => {
     if (!nickname) {
       router.push('/member/new/nickname');
     }
   }, []);
-
-  useEffect(() => {
-    if (value) {
-      if (value.length === MAX_DATE_LENGTH_UNTIL_DAY) {
-        const today = new Date();
-        const inputValue = new Date(value);
-
-        if (today < inputValue) {
-          toast.warning('올바른 생년월일을 입력해주세요.');
-          setIsValidBirth(false);
-          return;
-        }
-      }
-      setIsValidBirth(value.length === MAX_DATE_LENGTH_UNTIL_DAY);
-    }
-  }, [value]);
 
   return (
     <FormLayout

--- a/src/features/my/components/update/UpdateForm.tsx
+++ b/src/features/my/components/update/UpdateForm.tsx
@@ -8,6 +8,7 @@ import { MAX_DATE_LENGTH_UNTIL_DAY, MAX_NICKNAME_LENGTH, MAX_USERNAME_LENGTH } f
 import { DateInput } from '@/features/goal/components/new/DateInput';
 import { TextInput } from '@/features/goal/components/new/TextInput';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
+import { useValidBirth } from '@/hooks/useValidBirth';
 
 import type { UpdateMemberDataFormValues } from '../../types';
 
@@ -23,6 +24,7 @@ export const UpdateForm = () => {
   const { field: nicknameField } = useController({ name: 'nickname', control });
   const { field: birthField } = useController({ name: 'birth', control });
   const { field: usernameField } = useController({ name: 'username', control });
+  const isValidBirth = useValidBirth(birthField.value);
 
   const [isDisabledSubmit, setIsDisabledSubmit] = useState(true);
 
@@ -57,8 +59,8 @@ export const UpdateForm = () => {
       usernameField.value.length === 0 ||
       birthField.value.length !== 10;
 
-    setIsDisabledSubmit(isNotFilled || isNotModified);
-  }, [memberData, imageField, nicknameField, birthField, usernameField]);
+    setIsDisabledSubmit(isNotFilled || isNotModified || !isValidBirth);
+  }, [memberData, imageField, nicknameField, birthField, usernameField, isValidBirth]);
 
   return (
     <FormLayout

--- a/src/hooks/useValidBirth.ts
+++ b/src/hooks/useValidBirth.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+import { MAX_DATE_LENGTH_UNTIL_DAY } from '@/constants';
+
+import { useToast } from './useToast';
+
+export const useValidBirth = (value: string) => {
+  const toast = useToast();
+  const [isValid, setIsValid] = useState(false);
+
+  useEffect(() => {
+    if (value) {
+      if (value.length === MAX_DATE_LENGTH_UNTIL_DAY) {
+        const today = new Date();
+        const inputValue = new Date(value);
+
+        if (today < inputValue) {
+          toast.warning('올바른 생년월일을 입력해주세요.');
+          setIsValid(false);
+          return;
+        }
+      }
+      setIsValid(value.length === MAX_DATE_LENGTH_UNTIL_DAY);
+    }
+  }, [value]);
+
+  return isValid;
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [현재 날짜보다 미래의 날짜로 생년월일 설정이 가능](https://www.notion.so/depromeet/a8b9082115d44200b0d0a3307aac2394)

## 🎉 어떻게 해결했나요?
- 오늘 날짜를 기준으로 미래를 입력했을 경우, 버튼 disbaled 처리 및 toast 알림

### 📚 Attachment (Option)

#### ✔️ 온보딩 페이지

https://github.com/depromeet/amazing3-fe/assets/112946860/015e7bd8-a0bc-471c-8e04-94af5b26d957

#### ✔️ 정보 수정 페이지

https://github.com/depromeet/amazing3-fe/assets/112946860/5a2fec70-77c7-4284-96d5-88856b8317a0



