### PR TITLE
fix: 사용자 정보 업데이트 시, 로컬스토리지도 업데이트 되도록 수정

### DIFF
--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -16,9 +16,6 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (isSuccess) {
-      const username = methods.getValues('username');
-      localStorage.setItem('username', username);
-
       router.push('/my');
     }
   }, [isSuccess, router, methods]);

--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -12,14 +12,16 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
   const router = useRouter();
   const isMounted = useIsMounted();
   const { mutate, isSuccess } = useUpdateMemberData();
+  const methods = useForm<UpdateMemberDataFormValues>();
 
   useEffect(() => {
     if (isSuccess) {
+      const username = methods.getValues('username');
+      localStorage.setItem('username', username);
+
       router.push('/my');
     }
-  }, [isSuccess, router]);
-
-  const methods = useForm<UpdateMemberDataFormValues>();
+  }, [isSuccess, router, methods]);
 
   const submit = (formData: UpdateMemberDataFormValues) => {
     const { nickname, username, birth } = formData;

--- a/src/hooks/reactQuery/auth/useUpdateMemberData.ts
+++ b/src/hooks/reactQuery/auth/useUpdateMemberData.ts
@@ -20,7 +20,10 @@ export const useUpdateMemberData = () => {
 
   return useMutation({
     mutationFn: (data: UpdateMemberRequest) => api.put('/users', data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['memberData'] }),
+    onSuccess: (data) => {
+      localStorage.setItem('username', data.username);
+      queryClient.invalidateQueries({ queryKey: ['memberData'] });
+    },
     onError: (error: ResponseError) => {
       const errorMessage = error.status === 409 ? '이미 존재하는 아이디에요.' : '다시 시도해주세요.';
       toast.warning(`회원정보 수정에 실패했어요. ${errorMessage}`);


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 사용자 정보 업데이트 시, 로컬스토리지도 업데이트 되도록 수정

## 🎉 어떻게 해결했나요?
- 사용자 정보 업데이트 시, 로컬스토리지도 업데이트 되도록 수정

### 📚 Attachment (Option)
- 

