### PR TITLE
bug: 내 지도인지 아닌지에 따라 세부목표 화면 일부 수정

### DIFF
--- a/src/constants/storageKey.ts
+++ b/src/constants/storageKey.ts
@@ -1,0 +1,1 @@
+export const CURRENT_LIFEMAP_USERNAME_KEY = 'currentLifemapUsername';

--- a/src/features/goal/components/detail/DetailHeader.tsx
+++ b/src/features/goal/components/detail/DetailHeader.tsx
@@ -4,7 +4,7 @@ import { useOverlay } from '@toss/use-overlay';
 
 import CloseIcon from '@/assets/icons/goal/close-icon.svg';
 import DeleteIcon from '@/assets/icons/goal/delete-icon.svg';
-import { useGetMemberData } from '@/hooks/reactQuery/auth';
+import { useIsMyMap } from '@/hooks';
 
 import { DeleteGoalBottomSheet } from './DeleteGoalBottomSheet';
 
@@ -14,15 +14,15 @@ interface DetailHeaderProps {
 
 export const DetailHeader = ({ goalId }: DetailHeaderProps) => {
   const overlay = useOverlay();
-  const { data } = useGetMemberData();
+  const { isMyMap, currentUsername } = useIsMyMap();
 
   return (
     <>
-      <Link href={{ pathname: `/home/${data?.username}`, query: { id: goalId } }}>
+      <Link href={{ pathname: `/home/${currentUsername}`, query: { id: goalId } }}>
         <CloseIcon />
       </Link>
 
-      {goalId && (
+      {isMyMap && goalId && (
         <button
           onClick={() => {
             overlay.open(({ isOpen, close }) => {

--- a/src/features/goal/components/detail/GoalDetailContent.tsx
+++ b/src/features/goal/components/detail/GoalDetailContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { useIsMyMap } from '@/hooks';
 import { useGetGoal } from '@/hooks/reactQuery/goal';
 
 import { AddTaskInput } from './AddTaskInput';
@@ -10,6 +11,7 @@ import { Tasks } from './Tasks';
 import { AddSubGoalPrompt, ContentBody, DetailFooterButton, DetailHeader, Sticker } from '.';
 
 export const GoalDetailContent = ({ id }: { id: number }) => {
+  const { isMyMap } = useIsMyMap();
   const { data: goal } = useGetGoal({ goalId: Number(id) });
   const [isOpenTaskInput, setOpenTaskInput] = useState(false);
 
@@ -32,7 +34,7 @@ export const GoalDetailContent = ({ id }: { id: number }) => {
               {goal.tasks.length ? (
                 <Tasks goalId={id} tasks={goal.tasks} onOpenInput={handleOpenTaskInput(true)} />
               ) : (
-                !isOpenTaskInput && <AddSubGoalPrompt onClick={handleOpenTaskInput(true)} />
+                isMyMap && !isOpenTaskInput && <AddSubGoalPrompt onClick={handleOpenTaskInput(true)} />
               )}
             </div>
           )

--- a/src/features/goal/components/detail/Tasks.tsx
+++ b/src/features/goal/components/detail/Tasks.tsx
@@ -1,5 +1,6 @@
 import PlusIcon from '@/assets/icons/plus.svg';
 import { Typography } from '@/components';
+import { useIsMyMap } from '@/hooks';
 import type { GoalTasksProps } from '@/hooks/reactQuery/goal/useGetGoal';
 import { useUpdateIsDone } from '@/hooks/reactQuery/task';
 
@@ -13,14 +14,17 @@ interface TasksProps {
 
 export const Tasks = ({ goalId, tasks, onOpenInput }: TasksProps) => {
   const { mutate } = useUpdateIsDone();
+  const { isMyMap } = useIsMyMap();
 
   return (
     <div className="flex flex-col gap-4xs pb-4xl">
       <div className="flex justify-between">
         <Typography type="heading4">세부 목표</Typography>
-        <button onClick={onOpenInput}>
-          <PlusIcon width={20} height={20} />
-        </button>
+        {isMyMap && (
+          <button onClick={onOpenInput}>
+            <PlusIcon width={20} height={20} />
+          </button>
+        )}
       </div>
       {tasks.map(({ taskId, isTaskDone, taskDescription }) => (
         <Task

--- a/src/features/goal/components/detail/task/Task.tsx
+++ b/src/features/goal/components/detail/task/Task.tsx
@@ -8,7 +8,7 @@ import CheckedIcon from '@/assets/icons/goal/radio/radio-checked.svg';
 import UnCheckedIcon from '@/assets/icons/goal/radio/radio-unchecked.svg';
 import { Typography } from '@/components';
 import { TaskMoreOptionBottomSheet } from '@/features/goal/components/detail/TaskMoreOptionBottomSheet';
-import { useInput } from '@/hooks';
+import { useInput, useIsMyMap } from '@/hooks';
 import { useUpdateDescription } from '@/hooks/reactQuery/task/useUpdateDescription';
 
 import { TaskEditInput } from './TaskEditInput';
@@ -25,6 +25,7 @@ interface TaskProps {
 
 export const Task = ({ isDone = false, text, targetIds, onDoneClick }: TaskProps) => {
   const CheckIcon = isDone ? CheckedIcon : UnCheckedIcon;
+  const { isMyMap } = useIsMyMap();
   const { open } = useOverlay();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -56,7 +57,7 @@ export const Task = ({ isDone = false, text, targetIds, onDoneClick }: TaskProps
   return (
     <div className="w-full flex gap-6xs items-start px-3xs py-4xs rounded-[8px] border-gray-20 bg-white shadow-thumb">
       <div className="w-[24px] h-[24px]">
-        <button onClick={handleDoneClick}>
+        <button onClick={handleDoneClick} disabled={!isMyMap}>
           <CheckIcon width={24} height={24} />
         </button>
       </div>
@@ -70,9 +71,11 @@ export const Task = ({ isDone = false, text, targetIds, onDoneClick }: TaskProps
           <Typography type="body3" className="text-gray-70">
             {text}
           </Typography>
-          <button className="px-5xs" onClick={handleMoreOptionClick}>
-            <EllipsisVerticalIcon />
-          </button>
+          {isMyMap && (
+            <button className="px-5xs" onClick={handleMoreOptionClick}>
+              <EllipsisVerticalIcon />
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/features/home/components/lifeMap/LifeMap.tsx
+++ b/src/features/home/components/lifeMap/LifeMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CURRENT_LIFEMAP_USERNAME_KEY } from '@/constants/storageKey';
 import { PrivateLifeMap } from '@/features/home/components/lifeMap/PrivateLifeMap';
 import { PublicLifeMap } from '@/features/home/components/lifeMap/PublicLifeMap';
 
@@ -8,6 +9,8 @@ interface LifeMapContainerProps {
 }
 
 export const LifeMap = ({ username }: LifeMapContainerProps) => {
+  localStorage.setItem(CURRENT_LIFEMAP_USERNAME_KEY, username);
+
   const currentUsername = localStorage.getItem('username');
   const isMyMap = username === currentUsername;
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useDownloadImage } from './useDownloadImage';
 export { useFocusInput } from './useFocusInput';
 export { useInput } from './useInput';
 export { useIsMounted } from './useIsMounted';
+export { useIsMyMap } from './useIsMyMap';
 export { useOpenExternalBrowser } from './useOpenExternalBrowser';
 export { useOutsideClick } from './useOutsideClick';
 export { useScrollOnTrigger } from './useScrollOnTrigger';

--- a/src/hooks/useIsMyMap.ts
+++ b/src/hooks/useIsMyMap.ts
@@ -1,0 +1,12 @@
+import { CURRENT_LIFEMAP_USERNAME_KEY } from '@/constants/storageKey';
+
+import { useGetMemberData } from './reactQuery/auth';
+
+export const useIsMyMap = () => {
+  const currentUsername = localStorage.getItem(CURRENT_LIFEMAP_USERNAME_KEY);
+  const { data } = useGetMemberData();
+
+  const isMyMap = data?.username === currentUsername;
+
+  return { isMyMap, currentUsername, username: data?.username };
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [로그인한 사용자가 남의 목표 상세를 변경할 수 있는 문제 해결 (뒤로 가기 시 내 지도로 돌아가는 문제도 해결)](https://www.notion.so/depromeet/9de0c9b05d1c49d998844728eae0e166)

## 🎉 어떻게 해결했나요?
- 세부목표 화면에서 `x` 아이콘 클릭 시 **현재 보고 있던 인생지도로** 갈 수 있도록
- 다른 사람 세부목표일 경우, `수정/삭제/목표달성` 버튼 **비활성화 및 보이지 않도록** 

### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/112946860/5e42db9d-011f-490d-a355-56efd251abd8

