### PR TITLE
bug: 태그 폼 레이아웃 이슈 해결

### DIFF
--- a/src/features/goal/components/new/TagForm.tsx
+++ b/src/features/goal/components/new/TagForm.tsx
@@ -38,12 +38,16 @@ export const TagForm = () => {
         </Typography>
       }
       body={
-        <div {...register('tag')} className="flex flex-wrap justify-center gap-5xs overflow-auto pt-lg">
-          {tagsData?.map(({ id, content }) => (
-            <Tag key={id} isFocus={selectedTag == id} onClick={() => handleClickTag(id)}>
-              {content}
-            </Tag>
-          ))}
+        <div className="absolute h-[50%] inset-x-0 w-full pt-2xs">
+          <div className="h-[calc(100%-90px)] my-2xs px-2xs overflow-auto">
+            <div {...register('tag')} className="flex flex-wrap justify-center gap-5xs overflow-auto">
+              {tagsData?.map(({ id, content }) => (
+                <Tag key={id} isFocus={selectedTag == id} onClick={() => handleClickTag(id)}>
+                  {content}
+                </Tag>
+              ))}
+            </div>
+          </div>
         </div>
       }
       footer={


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [태그 선택 페이지 레이아웃 이슈](https://www.notion.so/depromeet/470491e28c4a4230a0847ad81d188024)

## 🎉 어떻게 해결했나요?
- 스타일 일부 수정

### 📚 Attachment (Option)

| AS-IS | TO-BE |
|:--:|:--:|
| <video src="https://github.com/depromeet/amazing3-fe/assets/112946860/8f9ee774-9369-4f5d-8108-faaaaeb81bf9" /> | <video src="https://github.com/depromeet/amazing3-fe/assets/112946860/ac7b837b-f186-4fc1-bcf4-e070bf7b54f7" /> |





