### PR TITLE
bug: 세부목표 추가 스텝 부분 이슈 및 빠진 부분 추가

### DIFF
--- a/src/components/atoms/toolTip/ToolTip.tsx
+++ b/src/components/atoms/toolTip/ToolTip.tsx
@@ -9,11 +9,11 @@ interface ToolTipProps {
 
 export const ToolTip = ({ title }: ToolTipProps) => {
   return (
-    <div className="w-fit px-3xs py-5xs flex items-center justify-center bg-blue-30 rounded-[12px] relative">
-      <Typography type="title5" className="text-white">
+    <div className="w-fit px-3xs py-5xs flex items-center justify-center bg-blue-10 rounded-[12px] relative">
+      <Typography type="title4" className="text-blue-30">
         {title}
       </Typography>
-      <ReverseTriangleIcon width={14} height={10} fill={colors.blue[30]} className="absolute bottom-[-9px]" />
+      <ReverseTriangleIcon width={14} height={10} fill={colors.blue[10]} className="absolute bottom-[-9px]" />
     </div>
   );
 };

--- a/src/features/goal/components/detail/SavedFooterButton.tsx
+++ b/src/features/goal/components/detail/SavedFooterButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 
-import { Button } from '@/components';
+import { Button, ToolTip } from '@/components';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
 
 interface SavedFooterButtonProps {
@@ -12,8 +12,13 @@ export const SavedFooterButton = ({ goalId }: SavedFooterButtonProps) => {
   const { data: memberData } = useGetMemberData();
 
   return (
-    <Link href={{ pathname: `/home/${memberData?.username}`, query: { id: goalId } }}>
-      <Button>홈으로 가기</Button>
-    </Link>
+    <div className="relative">
+      <div className="absolute w-full flex justify-center bottom-[90px]">
+        <ToolTip title="홈화면에서 세부목표를 정할 수 있어요" />
+      </div>
+      <Link href={{ pathname: `/home/${memberData?.username}`, query: { id: goalId } }}>
+        <Button>홈으로 가기</Button>
+      </Link>
+    </div>
   );
 };

--- a/src/features/goal/components/detail/SavedHeader.tsx
+++ b/src/features/goal/components/detail/SavedHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
 
-import BackIcon from '@/assets/icons/goal/back-icon.svg';
 import CloseIcon from '@/assets/icons/goal/close-icon.svg';
 import { Typography } from '@/components/atoms';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
@@ -17,14 +16,13 @@ export const SavedHeader = ({ goalId }: SavedHeaderProps) => {
   const query = { id: goalId };
 
   return (
-    <>
-      <Link href={{ pathname, query }}>
-        <BackIcon />
-      </Link>
+    <div className="w-full h-[20px] flex justify-center items-center">
       <Typography type="header1">목표 저장 완료!</Typography>
-      <Link href={{ pathname, query }}>
-        <CloseIcon />
-      </Link>
-    </>
+      <div className="absolute right-[24px]">
+        <Link href={{ pathname, query }}>
+          <CloseIcon />
+        </Link>
+      </div>
+    </div>
   );
 };

--- a/src/features/goal/components/new/GoalForm.tsx
+++ b/src/features/goal/components/new/GoalForm.tsx
@@ -46,6 +46,7 @@ export const GoalForm = () => {
             <div className="w-[200px]">
               <Button
                 className="py-3xs px-xs text-sm"
+                style={{ boxShadow: '0px 0px 1px 0px rgba(67, 95, 208, 0.17)' }}
                 variant="blue"
                 height="h44"
                 rounded="xl"

--- a/src/features/goal/components/new/MoreForm.tsx
+++ b/src/features/goal/components/new/MoreForm.tsx
@@ -20,7 +20,7 @@ export const MoreForm = () => {
   const { register, getValues, control } = useFormContext<GoalFormValues>();
   const router = useRouter();
   const { field } = useController({ name: 'content', control });
-  const { onChange } = field;
+  const { value, onChange } = field;
   const { mutate, isPending, data } = useCreateGoal();
 
   useEffect(() => {
@@ -65,6 +65,7 @@ export const MoreForm = () => {
             labelName="메모"
             maxLength={MAX_TEXTAREA_LENGTH}
             placeholder="ex) 꼬박꼬박 저금하자 아자자!"
+            value={value}
             onChange={onChange}
           />
         </div>

--- a/src/features/goal/components/new/MoreForm.tsx
+++ b/src/features/goal/components/new/MoreForm.tsx
@@ -65,6 +65,7 @@ export const MoreForm = () => {
             labelName="메모"
             maxLength={MAX_TEXTAREA_LENGTH}
             placeholder="ex) 꼬박꼬박 저금하자 아자자!"
+            height="25vh"
             value={value}
             onChange={onChange}
           />

--- a/src/features/goal/components/new/TextInput.tsx
+++ b/src/features/goal/components/new/TextInput.tsx
@@ -9,7 +9,7 @@ interface TextInputProps {
   labelName?: string;
   value?: string;
   type?: lineType;
-  height?: number;
+  height?: string;
   maxLength: number;
   placeholder: string;
   onChange?: (value: string) => void;
@@ -19,7 +19,7 @@ export const TextInput = ({
   labelName = '',
   value = '',
   type = 'single',
-  height = 140,
+  height = '140px',
   maxLength,
   placeholder,
   onChange,
@@ -48,7 +48,7 @@ export const TextInput = ({
         <Input type="text" value={value} placeholder={placeholder} onChange={handleChangeInput} />
       ) : (
         <Textarea
-          style={{ height: `${height}px` }}
+          style={{ height }}
           placeholder={placeholder}
           onChange={handleChangeInput as ChangeEventHandler<HTMLTextAreaElement>}
         />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [목표 작성 메모 입력 step](https://www.notion.so/depromeet/step-8bba5f2bcbaf4433b54361b7769fd25c)

## 🎉 어떻게 해결했나요?
- 메모 입력 필드 글자 수 카운트 되도록 반영
- 메모 입력 필드 height를 vh로 지정하여 버튼과 최대한 겹치지 않도록 스타일 적용
- 목표 저장 시 상단 `>` 버튼 제거
- 목표 저장 시 하단에 ToolTip 추가

### 📚 Attachment (Option)

| `>` 버튼 제거 및 ToolTip 추가 | 메모 입력 필드 글자수 카운트 및 레이아웃 수정 |
|:--:|:--:|
| <img src="https://github.com/depromeet/amazing3-fe/assets/112946860/71973969-4fc4-4535-a161-cd572a32fc3e" width="600" />| ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/01cdf83a-c5f8-4ff7-8f19-005c2a38c41a) |