### PR TITLE
chore: 목표 삭제 바텀시트에 nickname 표시 및 스타일 수정

### DIFF
--- a/src/features/goal/components/detail/DeleteGoalBottomSheet.tsx
+++ b/src/features/goal/components/detail/DeleteGoalBottomSheet.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import BandiMoori from '@/assets/images/bandi-moori.png';
 import { BottomSheet, Button, Typography } from '@/components/atoms';
 import { Spinner } from '@/components/atoms/spinner';
+import { useGetMemberData } from '@/hooks/reactQuery/auth';
 import { useDeleteGoal } from '@/hooks/reactQuery/goal';
 
 interface DeleteGoalBottomSheetProps {
@@ -13,6 +14,7 @@ interface DeleteGoalBottomSheetProps {
 
 export const DeleteGoalBottomSheet = ({ open, onClose, goalId }: DeleteGoalBottomSheetProps) => {
   const { mutate, isPending } = useDeleteGoal();
+  const { data } = useGetMemberData();
 
   const handleDelete = () => {
     if (!goalId) return;
@@ -24,17 +26,17 @@ export const DeleteGoalBottomSheet = ({ open, onClose, goalId }: DeleteGoalBotto
     <BottomSheet
       open={open}
       onDismiss={onClose}
-      fixedMaxHeight={520}
+      fixedMaxHeight={480}
       FooterComponent={<Footer onCancel={onClose} onDelete={handleDelete} isPending={isPending} />}
     >
-      <div className="h-[400px] flex flex-col items-center justify-center gap-3xs translate-y-[20px]">
-        <Typography type="title1" className="text-gray-70">
-          목표를 삭제하시겠어요?
+      <div className="flex flex-col items-center justify-center gap-3xs translate-y-[20px] pt-xs">
+        <Typography type="title1" className="text-gray-70 text-center">
+          {data?.nickname}님의 목표조각을 <br /> 삭제하시겠어요?
         </Typography>
         <Typography type="body3" className="text-gray-50">
           삭제하면 다시 복구할 수 없어요
         </Typography>
-        <Image src={BandiMoori} width={250} alt="bandi_moori" priority />
+        <Image src={BandiMoori} width={180} alt="bandi_moori" priority />
       </div>
     </BottomSheet>
   );
@@ -49,7 +51,7 @@ const Footer = ({
   onDelete: VoidFunction;
   isPending: boolean;
 }) => (
-  <div className="flex flex-row gap-xs">
+  <div className="flex flex-row gap-5xs px-4xs pb-4xs">
     <Button variant="tertiary" onClick={onCancel}>
       취소
     </Button>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [[목표 삭제] 버튼 간격 스타일, UX라이팅, 반디부디 크기 조정](https://www.notion.so/depromeet/UX-ce8039d124b941898b867cd07d1da218)

## 🎉 어떻게 해결했나요?
- nickname 표시
- 반디부디 이미지 크기 축소
- 스타일 일부 수정

### 📚 Attachment (Option)

| AS-IS | TO-BE |
|:--:|:--:|
| ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/31f8cef3-8c79-4abf-a50f-bb285f6c32d3) | ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/6e1186f3-61a0-43a3-b420-adccd4ce7029) |





