### PR TITLE
fix: 태그 선택 시, 버튼이 안눌리는 이슈 해결

### DIFF
--- a/src/features/goal/components/new/TagForm.tsx
+++ b/src/features/goal/components/new/TagForm.tsx
@@ -38,7 +38,7 @@ export const TagForm = () => {
         </Typography>
       }
       body={
-        <div className="absolute h-[50%] inset-x-0 w-full pt-2xs">
+        <div className="absolute h-[calc(50%-40px)] inset-x-0 w-full pt-2xs">
           <div className="h-[calc(100%-90px)] my-2xs px-2xs overflow-auto">
             <div {...register('tag')} className="flex flex-wrap justify-center gap-5xs overflow-auto">
               {tagsData?.map(({ id, content }) => (


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 태그 선택 시, 버튼이 안눌리는 이슈 해결

## 🎉 어떻게 해결했나요?
- 태그 영역의 높이에 버튼 일부가 겹쳐서 안눌리는 현상 해결

### 📚 Attachment (Option)
- 

