### PR TITLE
bug: 빈 목표 카드 선택 시 목표 생성 화면으로 redirection

### DIFF
--- a/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
+++ b/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import bandiboodiGray from '@/assets/images/bandi-boodi-gray.png';
 import { Typography } from '@/components';
@@ -13,11 +14,13 @@ const EMPTY_ALTERNATIVE_TEXTS = ['나의 3년 후는?', '목표 생각중..', '�
 
 export const EmptyMapCard = ({ alternativeTextIndex, position }: EmptyMapCardProps) => {
   return (
-    <MapCardLayout position={position} cursor="default">
-      <Image src={bandiboodiGray} width="100" height="100" alt="empty_goal" />
-      <Typography type="title5" className="text-gray-40 text-center font-bold">
-        {EMPTY_ALTERNATIVE_TEXTS[alternativeTextIndex]}
-      </Typography>
-    </MapCardLayout>
+    <Link href={{ pathname: '/goal/new/goal' }}>
+      <MapCardLayout position={position} cursor="default">
+        <Image src={bandiboodiGray} width="100" height="100" alt="empty_goal" />
+        <Typography type="title5" className="text-gray-40 text-center font-bold">
+          {EMPTY_ALTERNATIVE_TEXTS[alternativeTextIndex]}
+        </Typography>
+      </MapCardLayout>
+    </Link>
   );
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 제곧내

## 🎉 어떻게 해결했나요?
- 

### 📚 Attachment (Option)
- 

