### PR TITLE
bug: 남의 지도에서 빈 목표 카드 선택 시 사용자 상태에 따른 로직 분리

### DIFF
--- a/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
+++ b/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 import bandiboodiGray from '@/assets/images/bandi-boodi-gray.png';
 import { Typography } from '@/components';
+import { useIsMyMap } from '@/hooks';
 
 import { MapCardLayout, type MapCardLayoutProps } from '../MapCardLayout';
 
@@ -13,8 +14,10 @@ interface EmptyMapCardProps extends MapCardLayoutProps {
 const EMPTY_ALTERNATIVE_TEXTS = ['나의 3년 후는?', '목표 생각중..', '나는 갓생러 ㅋ', '성공이 뭘까?'];
 
 export const EmptyMapCard = ({ alternativeTextIndex, position }: EmptyMapCardProps) => {
+  const { isMyMap } = useIsMyMap();
+
   return (
-    <Link href={{ pathname: '/goal/new/goal' }}>
+    <Link href={{ pathname: isMyMap ? '/goal/new/goal' : '' }}>
       <MapCardLayout position={position} cursor="default">
         <Image src={bandiboodiGray} width="100" height="100" alt="empty_goal" />
         <Typography type="title5" className="text-gray-40 text-center font-bold">

--- a/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
+++ b/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
@@ -1,10 +1,14 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useOverlay } from '@toss/use-overlay';
+import { useAtomValue } from 'jotai';
 
 import bandiboodiGray from '@/assets/images/bandi-boodi-gray.png';
 import { Typography } from '@/components';
+import { isLoginAtom } from '@/features/auth/atom';
 import { useIsMyMap } from '@/hooks';
 
+import { LoginBottomSheet } from '../../loginBottomSheet';
 import { MapCardLayout, type MapCardLayoutProps } from '../MapCardLayout';
 
 interface EmptyMapCardProps extends MapCardLayoutProps {
@@ -14,16 +18,30 @@ interface EmptyMapCardProps extends MapCardLayoutProps {
 const EMPTY_ALTERNATIVE_TEXTS = ['나의 3년 후는?', '목표 생각중..', '나는 갓생러 ㅋ', '성공이 뭘까?'];
 
 export const EmptyMapCard = ({ alternativeTextIndex, position }: EmptyMapCardProps) => {
+  const router = useRouter();
+  const isLogin = useAtomValue(isLoginAtom);
   const { isMyMap } = useIsMyMap();
+  const { open } = useOverlay();
+
+  const handleMapCardClick = () => {
+    if (isMyMap) {
+      router.push(`/goal/new/goal`);
+    } else if (isLogin) {
+      // 로그인한 사용자가 내 지도가 아닌 카드를 클릭했을 때 어떤 작업을 해야하는지 의논 필요.
+      return;
+    } else {
+      open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
+    }
+  };
 
   return (
-    <Link href={{ pathname: isMyMap ? '/goal/new/goal' : '' }}>
+    <button onClick={handleMapCardClick}>
       <MapCardLayout position={position} cursor="default">
         <Image src={bandiboodiGray} width="100" height="100" alt="empty_goal" />
         <Typography type="title5" className="text-gray-40 text-center font-bold">
           {EMPTY_ALTERNATIVE_TEXTS[alternativeTextIndex]}
         </Typography>
       </MapCardLayout>
-    </Link>
+    </button>
   );
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 빈 카드 선택 시 goal 생성 화면으로 이동하는데 남의 지도에서는 그게 조금 이상함.

## 🎉 어떻게 해결했나요?
- 로그인한 사용자가 본인의 지도에서 빈 목표 클릭 시, 목표 생성 화면으로 이동.
- 로그인한 사용자가 남의 지도에서 빈 목표 클릭 시, 아무 동작 안함.
- 로그인하지 않은 사용자가 남의 지도에서 빈 목표 클릭 시, 로그인 버틈 시트 출력.

### 📚 Attachment (Option)
- 

