### PR TITLE
fix: 목표 조각에 box shadow 제거

### DIFF
--- a/src/features/home/components/MapCardCollections/MapCardLayout.tsx
+++ b/src/features/home/components/MapCardCollections/MapCardLayout.tsx
@@ -8,7 +8,7 @@ export interface MapCardLayoutProps {
 export const MapCardLayout = ({ position, cursor = 'cursor', children }: PropsWithChildren<MapCardLayoutProps>) => {
   return (
     <div
-      className={`flex flex-col items-center absolute w-[130px] h-[130px] rounded-lg bg-white p-[5px] shadow-thumb ${position.x} ${position.y} overflow-hidden cursor-${cursor}`}
+      className={`flex flex-col items-center absolute w-[130px] h-[130px] rounded-lg bg-white p-[5px] ${position.x} ${position.y} overflow-hidden cursor-${cursor}`}
     >
       {children}
     </div>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- ios safari에서 box-shadow가 제대로 렌더링 되지 않는 이슈를 해결했습니다
  - 관련 이슈: https://github.com/niklasvh/html2canvas/issues/1856 

## 🎉 어떻게 해결했나요?
- 이슈가 발생하는 요소에 box-shadow 제거

https://github.com/depromeet/amazing3-fe/assets/80238096/3c947a3f-f5fa-48d8-ba8d-218e518afb29



### 📚 Attachment (Option)
- 

