### PR TITLE
refactor: 세부목표 isDone 요청에 debounce 추가

### DIFF
--- a/src/features/goal/components/detail/Tasks.tsx
+++ b/src/features/goal/components/detail/Tasks.tsx
@@ -30,7 +30,7 @@ export const Tasks = ({ goalId, tasks, onOpenInput }: TasksProps) => {
         <Task
           key={taskId}
           text={taskDescription}
-          isDone={isTaskDone}
+          initialIsDone={isTaskDone}
           targetIds={{ goalId, taskId }}
           onDoneClick={() => mutate({ goalId, isDone: !isTaskDone, taskId })}
         />

--- a/src/features/goal/components/detail/task/Task.tsx
+++ b/src/features/goal/components/detail/task/Task.tsx
@@ -35,8 +35,8 @@ export const Task = ({ initialIsDone = false, text, targetIds, onDoneClick }: Ta
   const { mutate } = useUpdateDescription();
 
   const debounceHandleIsDone = useDebounceCall(() => {
-    if (initialIsDone !== isDone) onDoneClick();
-  }, 500);
+    onDoneClick();
+  });
 
   const handleDoneClick = () => {
     setIsDone((prev) => !prev);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useDebounceCall } from './useDebounceCall';
 export { useDownloadImage } from './useDownloadImage';
 export { useFocusInput } from './useFocusInput';
 export { useInput } from './useInput';

--- a/src/hooks/reactQuery/task/useUpdateIsDone.ts
+++ b/src/hooks/reactQuery/task/useUpdateIsDone.ts
@@ -2,9 +2,6 @@ import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 
-import type { GoalResponse } from '../goal/useGetGoal';
-import { useOptimisticUpdate } from '../useOptimisticUpdate';
-
 type IsDoneRequest = {
   goalId: number;
   taskId: number;
@@ -12,23 +9,7 @@ type IsDoneRequest = {
 };
 
 export const useUpdateIsDone = () => {
-  const { queryClient, optimisticUpdater } = useOptimisticUpdate();
-
   return useMutation({
     mutationFn: ({ taskId, isDone }: IsDoneRequest) => api.patch(`/task/${taskId}/isDone`, { isDone }),
-    onMutate: async ({ goalId, taskId, isDone }) => {
-      const targetQueryKey = ['goal', goalId];
-
-      const updater = (old: GoalResponse): GoalResponse => {
-        const updatedTask = old.tasks.map((task) => (task.taskId === taskId ? { ...task, isTaskDone: isDone } : task));
-        return { ...old, tasks: updatedTask };
-      };
-      const context = await optimisticUpdater({ queryKey: targetQueryKey, updater });
-      return context;
-    },
-    onError: (_, variable, context) => {
-      const targetQueryKey = ['goal', variable.goalId];
-      queryClient.setQueryData(targetQueryKey, context?.previous);
-    },
   });
 };

--- a/src/hooks/useDebounceCall.ts
+++ b/src/hooks/useDebounceCall.ts
@@ -1,21 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useRef } from 'react';
 
-export const useDebounceCall = (callback: VoidFunction, delay: number) => {
-  const [callNow, setCallNow] = useState(false);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      if (callNow) callback();
-      setCallNow(false);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [callNow, callback, delay]);
+export const useDebounceCall = (callback: VoidFunction, delay = 500) => {
+  const timeoutId = useRef<NodeJS.Timeout | null>(null);
 
   const triggerCall = () => {
-    setCallNow(true);
+    if (timeoutId.current) {
+      clearTimeout(timeoutId.current);
+    }
+
+    timeoutId.current = setTimeout(() => {
+      callback();
+    }, delay);
   };
 
   return triggerCall;

--- a/src/hooks/useDebounceCall.ts
+++ b/src/hooks/useDebounceCall.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+export const useDebounceCall = (callback: VoidFunction, delay: number) => {
+  const [callNow, setCallNow] = useState(false);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (callNow) callback();
+      setCallNow(false);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [callNow, callback, delay]);
+
+  const triggerCall = () => {
+    setCallNow(true);
+  };
+
+  return triggerCall;
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- https://github.com/depromeet/amazing3-fe/pull/107 에서 언급했던 체크박스가 **일정시간 유지되면 그때 요청**보내는 기능 추가

## 🎉 어떻게 해결했나요?
- debounce로 클릭할 때마다 요청 보내는 것이 아니라, 0.5초 유지 시에만 요청 보내도록 했습니다.
- 낙관적 업데이트하던 코드는 제거했습니다.

### 📚 Attachment (Option)
![isDone-after-debounce](https://github.com/depromeet/amazing3-fe/assets/112946860/1e432cf9-9a95-4d14-8728-8d0422cef6a0)