### PR TITLE
feat: 응원하기 개수 api 응답 값으로 수정

### DIFF
--- a/src/features/home/components/lifeMap/LifeMapInfo.tsx
+++ b/src/features/home/components/lifeMap/LifeMapInfo.tsx
@@ -15,33 +15,35 @@ interface LifeMapInfoProps {
 const LifeMapInfo = ({ goalsData }: LifeMapInfoProps) => {
   if (!goalsData) return null;
 
-  // TODO: 조회수, 응원하기 개수 api 호출
-  const { goalsCount } = goalsData;
+  const {
+    count: { cheering },
+    goalsCount,
+  } = goalsData;
 
   return (
     <div className="flex items-center mt-5xs">
       {goalsCount ? (
-        <div className="flex items-center">
-          <StarIcon width={20} height={20} fill={colors.blue[30]} className="inline-block mr-[4px]" />
-          <Typography type="title4" className="text-gray-50 mr-[2px]">
-            {`${formatOver999(goalsData.goalsCount)}`}
-          </Typography>
-          <Typography type="title4" className="text-gray-40">
-            개의 목표 조각
-          </Typography>
-        </div>
+        <>
+          <div className="flex items-center">
+            <StarIcon width={20} height={20} fill={colors.blue[30]} className="inline-block mr-[4px]" />
+            <Typography type="title4" className="text-gray-50 mr-[2px]">
+              {`${formatOver999(goalsData.goalsCount)}`}
+            </Typography>
+            <Typography type="title4" className="text-gray-40">
+              개의 목표 조각
+            </Typography>
+          </div>
+          <Divider className="mx-5xs" />
+        </>
       ) : (
         ''
       )}
 
-      <Divider className="mx-5xs" />
-
-      {/* TODO: 응원하기 개수 응답 값으로 수정 예정 */}
       <Link href="/my/cheering">
         <div className="flex items-center">
           <ThumbsIcon width={20} height={20} fill={colors.blue[30]} className="inline-block mr-[4px]" />
           <Typography type="title4" className="text-gray-50 mr-[2px]">
-            {formatOver999(1000)}
+            {formatOver999(cheering)}
           </Typography>
           <Typography type="title4" className="text-gray-40">
             개의 응원

--- a/src/hooks/reactQuery/goal/useGetGoals.ts
+++ b/src/hooks/reactQuery/goal/useGetGoals.ts
@@ -15,6 +15,11 @@ export type GoalResponse = {
   isPublic: boolean;
   goals: Array<GoalProps>;
   goalsCount: number;
+  count: {
+    cheering: number;
+    history: number;
+    view: number;
+  };
 };
 
 export const useGetGoals = () => {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 응원하기 개수 고정 값 -> api 응답 값으로 수정
- `/life-map` 응답 값에 추가된 `count` 값을 사용

## 🎉 어떻게 해결했나요?

<img src="https://github.com/depromeet/amazing3-fe/assets/80238096/5fad0326-3a82-4897-96d7-73b5fad4aebe" width="400px" />

### 📚 Attachment (Option)


