### PR TITLE
feat: 응원하기 개수 조회 api 연동

### DIFF
--- a/src/features/my/components/MyPageLayout.tsx
+++ b/src/features/my/components/MyPageLayout.tsx
@@ -30,7 +30,7 @@ export const MyPageLayout = () => {
           <div className="flex justify-center w-full ">
             <div className="flex flex-col w-[349px] mt-3xs px-3xs py-5xs bg-white rounded-lg shadow-[0_1.001px_40px_0_rgba(197,229,255,0.3)] divide-y">
               <LifeMapPrivacySetting isPublic={memberData.lifeMap.isPublic} />
-              <MyPageLifeMapInfo />
+              <MyPageLifeMapInfo username={memberData.username} />
             </div>
           </div>
           <MyPageBody />

--- a/src/features/my/components/MyPageLifeMapInfo.tsx
+++ b/src/features/my/components/MyPageLifeMapInfo.tsx
@@ -5,9 +5,16 @@ import ForwardIcon from '@/assets/icons/forward-icon.svg';
 import LikeIcon from '@/assets/icons/like-icon.png';
 import MapIcon from '@/assets/icons/map-icon.png';
 import { Typography } from '@/components';
+import { useGetCheeringCount } from '@/hooks/reactQuery/cheering';
 import { formatOver999 } from '@/utils/number';
 
-const MyPageLifeMapInfo = () => {
+interface MyPageLifeMapInfoProps {
+  username: string;
+}
+
+const MyPageLifeMapInfo = ({ username }: MyPageLifeMapInfoProps) => {
+  const { data } = useGetCheeringCount({ username });
+
   return (
     <div>
       <div className="flex items-center gap-[8px] py-[13px] w-full">
@@ -16,7 +23,7 @@ const MyPageLifeMapInfo = () => {
           <Typography type="title4" className="text-gray-40">
             내가 받은 응원
           </Typography>
-          <Typography type="title4">{`${formatOver999(1000)}명`}</Typography>
+          <Typography type="title4">{`${formatOver999(data?.count || 0)}명`}</Typography>
         </div>
         <Link href="/my/cheering">
           <ForwardIcon />

--- a/src/hooks/reactQuery/cheering/index.ts
+++ b/src/hooks/reactQuery/cheering/index.ts
@@ -1,0 +1,1 @@
+export { useGetCheeringCount } from './useGetCheeringCount';

--- a/src/hooks/reactQuery/cheering/useGetCheeringCount.ts
+++ b/src/hooks/reactQuery/cheering/useGetCheeringCount.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/apis';
+
+export type CheeringCountRequest = {
+  username: string;
+};
+
+export type CheeringCountResponse = {
+  count: number;
+};
+
+export const useGetCheeringCount = ({ username }: CheeringCountRequest) => {
+  return useQuery<CheeringCountResponse>({
+    queryKey: ['cheering', username],
+    queryFn: () => api.get<CheeringCountResponse>(`/cheering/count/${username}`),
+  });
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 응원하기 개수 조회 api 연동
  - 조회수 조회 api는 별도로 없고, `/life-map` 조회할 때만 있어서 추후 서버에 작업 요청 예정입니다 

## 🎉 어떻게 해결했나요?

<img width="516" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/80238096/47bcbe1e-c8a0-4bbd-8d9f-84000c2edbda">


### 📚 Attachment (Option)
- 

