### PR TITLE
bug: 스플래시 화면에서 뒷 배경 길이 조절

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ const SplashPage = () => {
       <div className="absolute top-0 right-0">
         <Image src={PurpleBlurImage} sizes="100vw" alt="blur_image" />
       </div>
-      <div className="w-full h-[60vh] bg-gradient1 flex flex-col items-center">
+      <div className="w-full h-[65vh] bg-gradient1 flex flex-col items-center">
         <div className="h-[38vh] flex flex-col gap-[1vh] z-10 justify-center">
           <Typography type="heading2" className="text-center bg-clip-text bg-gradient4 text-transparent">
             내가 직접 그리는 <br /> 나의 인생지도


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 에브리타임으로 홍보 해서 인앱 브라우저로 들어갔는데, 다크모드에서 이래 보이네용

<img src="https://github.com/depromeet/amazing3-fe/assets/112946860/11e31620-ccde-4dd8-9278-a03512426624" width="400" />

## 🎉 어떻게 해결했나요?

아래 표시한 부분이 조금 짧은 거 같아서 살짝만 늘렸어요~~!

<img width="1232" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/112946860/0c67a604-3355-491c-99fa-1e049f7a26a0">


### 📚 Attachment (Option)
- N/A

