### PR TITLE
feat: 1분에 한 번만 응원하기 누를 수 있도록 구현

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export { blueDataURL } from './blurDataURL';
 export * from './input';
 export { META } from './metadata';
+export * from './time';
 export * from './tokenKey';

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,0 +1,1 @@
+export const CHEER_INTERVAL = 60 * 1000;

--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -11,6 +11,7 @@ import { useThrottle } from '@/hooks';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
 import { useCreateCheering } from '@/hooks/reactQuery/cheering';
 import { useGetPublicGoals } from '@/hooks/reactQuery/goal/useGetPublicGoals';
+import { useToast } from '@/hooks/useToast';
 
 import { LoginBottomSheet } from '../loginBottomSheet';
 
@@ -22,10 +23,13 @@ export const PublicLifeMap = ({ username }: { username: string }) => {
   const { data: publicGoals } = useGetPublicGoals({ username });
 
   const { open } = useOverlay();
+  const toast = useToast();
   const [isCheeringSuccess, setIsCheeringSuccess] = useState(false);
 
   // TODO: Lottie atom을 수정해서 로티 이미지를 플레이하는 방식으로 변경
   const { mutate: cheer, isSuccess } = useCreateCheering(username);
+
+  const CHEER_ANIMATION_INTERVAL = 5400;
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined;
@@ -33,7 +37,7 @@ export const PublicLifeMap = ({ username }: { username: string }) => {
       setIsCheeringSuccess(true);
       timeoutId = setTimeout(() => {
         setIsCheeringSuccess(false);
-      }, 5400);
+      }, CHEER_ANIMATION_INTERVAL);
     }
 
     return () => {
@@ -52,6 +56,8 @@ export const PublicLifeMap = ({ username }: { username: string }) => {
       open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
       return;
     }
+
+    if (!isCheeringSuccess) toast.warning('1분 뒤에 응원할 수 있어요.');
 
     throttleCheer();
   };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useIsMyMap } from './useIsMyMap';
 export { useOpenExternalBrowser } from './useOpenExternalBrowser';
 export { useOutsideClick } from './useOutsideClick';
 export { useScrollOnTrigger } from './useScrollOnTrigger';
+export { useThrottle } from './useThrottle';

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+
+export const useThrottle = (callback: () => void, interval = 500) => {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return () => {
+    if (!timer.current) {
+      callback();
+
+      timer.current = setTimeout(() => {
+        callback();
+        timer.current = null;
+      }, interval);
+    }
+  };
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 1분에 한 번만 응원하기 누를 수 있도록 구현

## 🎉 어떻게 해결했나요?
- useThrottle 훅 추가

https://github.com/depromeet/amazing3-fe/assets/80238096/cb0379d1-45ed-47f6-a1d7-d8f21e981acf



### 📚 Attachment (Option)
- 

