### PR TITLE
bug: username에 BANDIBOODI가 포함된 경우 validation 실패 처리

### DIFF
--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -3,7 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { DevTool } from '@hookform/devtools';
 
-import { useUpdateMemberData } from '@/hooks/reactQuery/auth';
+import { useGetMemberData, useUpdateMemberData } from '@/hooks/reactQuery/auth';
 import { useIsMounted } from '@/hooks/useIsMounted';
 import { useToast } from '@/hooks/useToast';
 
@@ -12,6 +12,7 @@ import type { UpdateMemberDataFormValues } from '../types';
 const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
   const router = useRouter();
   const isMounted = useIsMounted();
+  const { data: memberData } = useGetMemberData();
   const { mutate, isSuccess } = useUpdateMemberData();
   const methods = useForm<UpdateMemberDataFormValues>();
   const toast = useToast();
@@ -26,7 +27,7 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
     const { nickname, username, birth } = formData;
     if (!nickname || !username || !birth) return;
 
-    if (username.toUpperCase().startsWith('BANDIBOODI-')) {
+    if (memberData?.username !== username && username.toUpperCase().startsWith('BANDIBOODI-')) {
       toast.warning('BANDIBOODI-로 시작하는 닉네임은 사용할 수 없습니다.');
       return;
     }

--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -5,6 +5,7 @@ import { DevTool } from '@hookform/devtools';
 
 import { useUpdateMemberData } from '@/hooks/reactQuery/auth';
 import { useIsMounted } from '@/hooks/useIsMounted';
+import { useToast } from '@/hooks/useToast';
 
 import type { UpdateMemberDataFormValues } from '../types';
 
@@ -13,6 +14,7 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
   const isMounted = useIsMounted();
   const { mutate, isSuccess } = useUpdateMemberData();
   const methods = useForm<UpdateMemberDataFormValues>();
+  const toast = useToast();
 
   useEffect(() => {
     if (isSuccess) {
@@ -23,6 +25,11 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
   const submit = (formData: UpdateMemberDataFormValues) => {
     const { nickname, username, birth } = formData;
     if (!nickname || !username || !birth) return;
+
+    if (username.toUpperCase().startsWith('BANDIBOODI-')) {
+      toast.warning('BANDIBOODI-로 시작하는 닉네임은 사용할 수 없습니다.');
+      return;
+    }
 
     // Convert birth from "YYYY.MM.DD" to "YYYY-MM-DD"
     // TODO: 서버에서 YYYY.MM.DD 형식을 지원하면 이 부분 삭제


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 사용자가 username 변경 시 `BANDIBOODI-`로 시작하는 이름으로 설정하면 이후 신규 유저 등록 과정에서 오류가 발생할 가능성이 있음.


## 🎉 어떻게 해결했나요?
- form submit 시 username 체크 로직 추가. -> `BANDIBOODI-`로 시작하는 이름으로 설정했을 때 토스트로 알림.

참고:
- 현재 Input atom의 커버리지가 지나치게 사용되고 있어 용례에 따라 구분할 필요가 있어보입니다.
- 따라서, error 상태를 따로 추가하기 보다는 나중에 validation을 수행하는 input atom을 별도로 만들어서 처리하겠습니다.


### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/34956359/b6c27edd-a6e0-43a3-961e-c31e0abaea4c
