### PR TITLE
chore: 홈화면에 dynamic으로 meta 및 og 적용

### DIFF
--- a/src/app/home/[username]/layout.tsx
+++ b/src/app/home/[username]/layout.tsx
@@ -1,7 +1,15 @@
 import type { PropsWithChildren } from 'react';
+import type { Metadata } from 'next';
 import Image from 'next/image';
 
 import PurpleBlurImage from '@/assets/images/purple-blur.png';
+import { getMetadata } from '@/utils/getMetadata';
+
+import type { HomeRouteParams } from './page';
+
+export const generateMetadata = async ({ params: { username } }: HomeRouteParams): Promise<Metadata> => {
+  return getMetadata({ title: `반짝반짝 빛날 ${username}님의 인생지도`, asPath: `/home/${username}` });
+};
 
 const HomeLayout = ({ children }: PropsWithChildren) => {
   return (

--- a/src/app/home/[username]/opengraph-image.tsx
+++ b/src/app/home/[username]/opengraph-image.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable @next/next/no-img-element */
+import { ImageResponse } from 'next/og';
+
+import type { HomeRouteParams } from './page';
+
+export const runtime = 'edge';
+export const contentType = 'image/png';
+export const alt = '인생지도 공유';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+const OGImage = async ({ params: { username } }: HomeRouteParams) => {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '630px',
+          position: 'relative',
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <img
+          src="https://github.com/depromeet/amazing3-fe/assets/112946860/7a8b32bd-fd97-4a32-91a8-7c6d151c6c91"
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            width: '100%',
+            objectFit: 'cover',
+          }}
+          alt="ogImage"
+        />
+        <p
+          style={{
+            position: 'absolute',
+            top: '254px',
+            fontSize: '36px',
+            fontWeight: '600',
+            color: 'white',
+          }}
+        >
+          @ {username}
+        </p>
+      </div>
+    ),
+  );
+};
+
+export default OGImage;

--- a/src/app/home/[username]/twitter-image.tsx
+++ b/src/app/home/[username]/twitter-image.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable @next/next/no-img-element */
+import { ImageResponse } from 'next/og';
+
+import type { HomeRouteParams } from './page';
+
+export const runtime = 'edge';
+export const contentType = 'image/png';
+export const alt = '인생지도 공유';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+const OGImage = async ({ params: { username } }: HomeRouteParams) => {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '630px',
+          position: 'relative',
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <img
+          src="https://github.com/depromeet/amazing3-fe/assets/112946860/7a8b32bd-fd97-4a32-91a8-7c6d151c6c91"
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            width: '100%',
+            objectFit: 'cover',
+          }}
+          alt="ogImage"
+        />
+        <p
+          style={{
+            position: 'absolute',
+            top: '254px',
+            fontSize: '36px',
+            fontWeight: '600',
+            color: 'white',
+          }}
+        >
+          @ {username}
+        </p>
+      </div>
+    ),
+  );
+};
+
+export default OGImage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,48 +1,16 @@
-import type { Metadata, Viewport } from 'next';
+import type { Viewport } from 'next';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 
-import { META } from '@/constants';
 import Providers from '@/contexts/Providers';
 import { GoogleAnalytics } from '@/features/analyzer';
+import { getMetadata } from '@/utils/getMetadata';
 
 import { insungIt, pretendard } from './fonts';
 
 import './globals.css';
 
-export const metadata: Metadata = {
-  metadataBase: new URL(META.url),
-  alternates: {
-    canonical: '/',
-  },
-  title: META.title,
-  description: META.description,
-  keywords: [...META.keyword],
-  openGraph: {
-    title: META.title,
-    description: META.description,
-    siteName: META.siteName,
-    locale: 'ko_KR',
-    type: 'website',
-    url: META.url,
-    images: {
-      url: META.ogImage,
-    },
-  },
-  verification: {
-    google: META.googleVerification,
-    other: {
-      'naver-site-verification': META.naverVerification,
-    },
-  },
-  twitter: {
-    title: META.title,
-    description: META.description,
-    images: {
-      url: META.ogImage,
-    },
-  },
-};
+export const metadata = getMetadata();
 
 export const viewport: Viewport = {
   width: 'device-width',

--- a/src/utils/getMetadata.ts
+++ b/src/utils/getMetadata.ts
@@ -9,8 +9,8 @@ interface generateMetadataProps {
   ogImage?: string;
 }
 
-export const getMetadata = (seoProps?: generateMetadataProps) => {
-  const { title, description, asPath, ogImage } = seoProps || {};
+export const getMetadata = (metadataProps?: generateMetadataProps) => {
+  const { title, description, asPath, ogImage } = metadataProps || {};
 
   const TITLE = title ? `${title} | 반디부디` : META.title;
   const DESCRIPTION = description || META.description;
@@ -28,10 +28,10 @@ export const getMetadata = (seoProps?: generateMetadataProps) => {
     openGraph: {
       title: TITLE,
       description: DESCRIPTION,
-      siteName: META.siteName,
+      siteName: TITLE,
       locale: 'ko_KR',
       type: 'website',
-      url: META.url,
+      url: PAGE_URL,
       images: {
         url: OG_IMAGE,
       },


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 홈화면에 dynamic하게 meta 및 og 적용

## 🎉 어떻게 해결했나요?
![image](https://github.com/depromeet/amazing3-fe/assets/112946860/1d37c4f7-08a8-4d63-8f06-c9fd843822ed)
![image](https://github.com/depromeet/amazing3-fe/assets/112946860/6a68a9a3-3fbd-4113-b3f8-43fb2f4ee0ff)


### 📚 Attachment (Option)
- 가랏...........!!!
- 로컬에서 dynamic ogImage 잘 뜨는 거 확인 됐긴 했는데...... 배포되고 봐야합니다 😓...