### PR TITLE
Bug: username 수정 제한 설정 및 응원하기 수행 조건 추가

### DIFF
--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -52,7 +52,7 @@ export const PublicLifeMap = ({ username }: { username: string }) => {
   const throttleCheer = useThrottle(() => cheer({ lifeMapId: publicGoals?.lifeMapId }), CHEER_INTERVAL);
 
   const handleClickCheeringButton = () => {
-    if (!memberData) {
+    if (!memberData?.nickname) {
       open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
       return;
     }

--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -27,8 +27,15 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
     const { nickname, username, birth } = formData;
     if (!nickname || !username || !birth) return;
 
+    // TODO: react-hook-form을 사용하는 input field는 별도로 component로 분리해서 에러 상태에 대한 처리를 할 수 있도록 수정
     if (memberData?.username !== username && username.toUpperCase().startsWith('BANDIBOODI-')) {
       toast.warning('BANDIBOODI-로 시작하는 닉네임은 사용할 수 없습니다.');
+      return;
+    }
+
+    // Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.
+    if (!/^[a-zA-Z0-9]+(-?[a-zA-Z0-9])*[a-zA-Z0-9]$/.test(username)) {
+      toast.warning('닉네임은 영문, 숫자, 하이픈(-)만 사용할 수 있고, 하이픈(-)은 처음과 끝에 사용할 수 없습니다.');
       return;
     }
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 이슈 1: username이 없는 경우에 응원하기 불가하도록 수정
- 이슈 2: username 수정 시 영문, 숫자, - 만 사용 가능하고, 시작과 끝은 - 가 들어갈 수 없음.

## 🎉 어떻게 해결했나요?
- 이슈 1: username이 없는 경우에 응원하기 불가하도록 수정

https://github.com/depromeet/amazing3-fe/assets/34956359/7758a7c4-7e14-4c08-95bf-f0f19a41076f




- 이슈 2: username 수정 시 영문, 숫자, - 만 사용 가능하고, 시작과 끝은 - 가 들어갈 수 없음.



https://github.com/depromeet/amazing3-fe/assets/34956359/663ebcb7-3a2e-4c1f-99ac-2a82f077526f




### 📚 Attachment (Option)
- 

