### PR TITLE
refactor: 인생지도 페이지 성능 개선

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -30,8 +30,6 @@ const RAW_RUNTIME_STATE =
           ["@radix-ui/react-icons", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:1.3.0"],\
           ["@radix-ui/react-portal", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:1.0.4"],\
           ["@radix-ui/react-tabs", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:1.0.4"],\
-          ["@sentry/nextjs", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"],\
           ["@storybook/addon-essentials", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.5.3"],\
           ["@storybook/addon-interactions", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.5.3"],\
           ["@storybook/addon-links", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.5.3"],\
@@ -7086,281 +7084,11 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["@rollup/plugin-commonjs", [\
-      ["npm:24.0.0", {\
-        "packageLocation": "./.yarn/cache/@rollup-plugin-commonjs-npm-24.0.0-b18d79acac-10c0.zip/node_modules/@rollup/plugin-commonjs/",\
-        "packageDependencies": [\
-          ["@rollup/plugin-commonjs", "npm:24.0.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:f85a24cd7249cbf55993a720e319ff07eec708b84af0539161ec0749b373c97ed32ae133a24dd3d6c3ae19b98d63d2acc657d2aadb999fdda2a9c2705e78151d#npm:24.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/@rollup-plugin-commonjs-virtual-ff91a8a65f/0/cache/@rollup-plugin-commonjs-npm-24.0.0-b18d79acac-10c0.zip/node_modules/@rollup/plugin-commonjs/",\
-        "packageDependencies": [\
-          ["@rollup/plugin-commonjs", "virtual:f85a24cd7249cbf55993a720e319ff07eec708b84af0539161ec0749b373c97ed32ae133a24dd3d6c3ae19b98d63d2acc657d2aadb999fdda2a9c2705e78151d#npm:24.0.0"],\
-          ["@rollup/pluginutils", "virtual:ff91a8a65fddf63f5ad1da1e7430edce2244efab0cd67092fac1a11078121174be44c28b151ccc8f2c5baf3b2b6f1950deae41cdf4947220675888e357e56b19#npm:5.1.0"],\
-          ["@types/rollup", null],\
-          ["commondir", "npm:1.0.1"],\
-          ["estree-walker", "npm:2.0.2"],\
-          ["glob", "npm:8.1.0"],\
-          ["is-reference", "npm:1.2.1"],\
-          ["magic-string", "npm:0.27.0"],\
-          ["rollup", "npm:2.78.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/rollup",\
-          "rollup"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@rollup/pluginutils", [\
-      ["npm:5.1.0", {\
-        "packageLocation": "./.yarn/cache/@rollup-pluginutils-npm-5.1.0-6939820ef8-10c0.zip/node_modules/@rollup/pluginutils/",\
-        "packageDependencies": [\
-          ["@rollup/pluginutils", "npm:5.1.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:ff91a8a65fddf63f5ad1da1e7430edce2244efab0cd67092fac1a11078121174be44c28b151ccc8f2c5baf3b2b6f1950deae41cdf4947220675888e357e56b19#npm:5.1.0", {\
-        "packageLocation": "./.yarn/__virtual__/@rollup-pluginutils-virtual-87b72af0d7/0/cache/@rollup-pluginutils-npm-5.1.0-6939820ef8-10c0.zip/node_modules/@rollup/pluginutils/",\
-        "packageDependencies": [\
-          ["@rollup/pluginutils", "virtual:ff91a8a65fddf63f5ad1da1e7430edce2244efab0cd67092fac1a11078121174be44c28b151ccc8f2c5baf3b2b6f1950deae41cdf4947220675888e357e56b19#npm:5.1.0"],\
-          ["@types/estree", "npm:1.0.5"],\
-          ["@types/rollup", null],\
-          ["estree-walker", "npm:2.0.2"],\
-          ["picomatch", "npm:2.3.1"],\
-          ["rollup", "npm:2.78.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/rollup",\
-          "rollup"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["@rushstack/eslint-patch", [\
       ["npm:1.5.1", {\
         "packageLocation": "./.yarn/cache/@rushstack-eslint-patch-npm-1.5.1-caed8f5804-10c0.zip/node_modules/@rushstack/eslint-patch/",\
         "packageDependencies": [\
           ["@rushstack/eslint-patch", "npm:1.5.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry-internal/feedback", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-internal-feedback-npm-7.91.0-c26a8e27b8-10c0.zip/node_modules/@sentry-internal/feedback/",\
-        "packageDependencies": [\
-          ["@sentry-internal/feedback", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry-internal/tracing", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-internal-tracing-npm-7.91.0-3f7019e90f-10c0.zip/node_modules/@sentry-internal/tracing/",\
-        "packageDependencies": [\
-          ["@sentry-internal/tracing", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/browser", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-browser-npm-7.91.0-cecb31f0ff-10c0.zip/node_modules/@sentry/browser/",\
-        "packageDependencies": [\
-          ["@sentry/browser", "npm:7.91.0"],\
-          ["@sentry-internal/feedback", "npm:7.91.0"],\
-          ["@sentry-internal/tracing", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/replay", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/cli", [\
-      ["npm:1.77.1", {\
-        "packageLocation": "./.yarn/unplugged/@sentry-cli-npm-1.77.1-ffa1e2e09c/node_modules/@sentry/cli/",\
-        "packageDependencies": [\
-          ["@sentry/cli", "npm:1.77.1"],\
-          ["https-proxy-agent", "npm:5.0.1"],\
-          ["mkdirp", "npm:0.5.6"],\
-          ["node-fetch", "virtual:017b14e33dc24496ace239ade2b5640ed536b1269040d3967889e91041f773a863c46aedbc2262a41a584ccc9a00fc7c284e30859c940aa03a3ba62080987605#npm:2.7.0"],\
-          ["progress", "npm:2.0.3"],\
-          ["proxy-from-env", "npm:1.1.0"],\
-          ["which", "npm:2.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/core", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-core-npm-7.91.0-67ba791446-10c0.zip/node_modules/@sentry/core/",\
-        "packageDependencies": [\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/integrations", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-integrations-npm-7.91.0-0670312a7c-10c0.zip/node_modules/@sentry/integrations/",\
-        "packageDependencies": [\
-          ["@sentry/integrations", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"],\
-          ["localforage", "npm:1.10.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/nextjs", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-nextjs-npm-7.91.0-5203cd0f56-10c0.zip/node_modules/@sentry/nextjs/",\
-        "packageDependencies": [\
-          ["@sentry/nextjs", "npm:7.91.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.91.0", {\
-        "packageLocation": "./.yarn/__virtual__/@sentry-nextjs-virtual-f85a24cd72/0/cache/@sentry-nextjs-npm-7.91.0-5203cd0f56-10c0.zip/node_modules/@sentry/nextjs/",\
-        "packageDependencies": [\
-          ["@sentry/nextjs", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.91.0"],\
-          ["@rollup/plugin-commonjs", "virtual:f85a24cd7249cbf55993a720e319ff07eec708b84af0539161ec0749b373c97ed32ae133a24dd3d6c3ae19b98d63d2acc657d2aadb999fdda2a9c2705e78151d#npm:24.0.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/integrations", "npm:7.91.0"],\
-          ["@sentry/node", "npm:7.91.0"],\
-          ["@sentry/react", "virtual:f85a24cd7249cbf55993a720e319ff07eec708b84af0539161ec0749b373c97ed32ae133a24dd3d6c3ae19b98d63d2acc657d2aadb999fdda2a9c2705e78151d#npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"],\
-          ["@sentry/vercel-edge", "npm:7.91.0"],\
-          ["@sentry/webpack-plugin", "npm:1.21.0"],\
-          ["@types/next", null],\
-          ["@types/react", "npm:18.2.37"],\
-          ["@types/webpack", null],\
-          ["chalk", "npm:3.0.0"],\
-          ["next", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:14.0.2"],\
-          ["react", "npm:18.2.0"],\
-          ["resolve", "patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"],\
-          ["rollup", "npm:2.78.0"],\
-          ["stacktrace-parser", "npm:0.1.10"],\
-          ["webpack", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:5.89.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/next",\
-          "@types/react",\
-          "@types/webpack",\
-          "next",\
-          "react",\
-          "webpack"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/node", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-node-npm-7.91.0-7c7ccbc13d-10c0.zip/node_modules/@sentry/node/",\
-        "packageDependencies": [\
-          ["@sentry/node", "npm:7.91.0"],\
-          ["@sentry-internal/tracing", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"],\
-          ["https-proxy-agent", "npm:5.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/react", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-react-npm-7.91.0-e4c9e245ff-10c0.zip/node_modules/@sentry/react/",\
-        "packageDependencies": [\
-          ["@sentry/react", "npm:7.91.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:f85a24cd7249cbf55993a720e319ff07eec708b84af0539161ec0749b373c97ed32ae133a24dd3d6c3ae19b98d63d2acc657d2aadb999fdda2a9c2705e78151d#npm:7.91.0", {\
-        "packageLocation": "./.yarn/__virtual__/@sentry-react-virtual-4dda987820/0/cache/@sentry-react-npm-7.91.0-e4c9e245ff-10c0.zip/node_modules/@sentry/react/",\
-        "packageDependencies": [\
-          ["@sentry/react", "virtual:f85a24cd7249cbf55993a720e319ff07eec708b84af0539161ec0749b373c97ed32ae133a24dd3d6c3ae19b98d63d2acc657d2aadb999fdda2a9c2705e78151d#npm:7.91.0"],\
-          ["@sentry/browser", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"],\
-          ["@types/react", "npm:18.2.37"],\
-          ["hoist-non-react-statics", "npm:3.3.2"],\
-          ["react", "npm:18.2.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/react",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/replay", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-replay-npm-7.91.0-057a5ece6d-10c0.zip/node_modules/@sentry/replay/",\
-        "packageDependencies": [\
-          ["@sentry/replay", "npm:7.91.0"],\
-          ["@sentry-internal/tracing", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/types", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-types-npm-7.91.0-cff635972d-10c0.zip/node_modules/@sentry/types/",\
-        "packageDependencies": [\
-          ["@sentry/types", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/utils", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-utils-npm-7.91.0-ee32f0b121-10c0.zip/node_modules/@sentry/utils/",\
-        "packageDependencies": [\
-          ["@sentry/utils", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/vercel-edge", [\
-      ["npm:7.91.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-vercel-edge-npm-7.91.0-9ecf1e2451-10c0.zip/node_modules/@sentry/vercel-edge/",\
-        "packageDependencies": [\
-          ["@sentry/vercel-edge", "npm:7.91.0"],\
-          ["@sentry-internal/tracing", "npm:7.91.0"],\
-          ["@sentry/core", "npm:7.91.0"],\
-          ["@sentry/types", "npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@sentry/webpack-plugin", [\
-      ["npm:1.21.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-webpack-plugin-npm-1.21.0-0d5f07e5b7-10c0.zip/node_modules/@sentry/webpack-plugin/",\
-        "packageDependencies": [\
-          ["@sentry/webpack-plugin", "npm:1.21.0"],\
-          ["@sentry/cli", "npm:1.77.1"],\
-          ["webpack-sources", "npm:3.2.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -10677,14 +10405,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:6.0.2", {\
-        "packageLocation": "./.yarn/cache/agent-base-npm-6.0.2-428f325a93-10c0.zip/node_modules/agent-base/",\
-        "packageDependencies": [\
-          ["agent-base", "npm:6.0.2"],\
-          ["debug", "virtual:2f4f5d4be0c4271f81a756602d102e02c292a5b30d8b7f5dd19d5368d75df8bb2f1bf516e3f835c2b5501d1663eb437d4f00d6d057bcaee770b46e87267a0fa3#npm:4.3.4"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:7.1.0", {\
         "packageLocation": "./.yarn/cache/agent-base-npm-7.1.0-4b12ba5111-10c0.zip/node_modules/agent-base/",\
         "packageDependencies": [\
@@ -10803,8 +10523,6 @@ const RAW_RUNTIME_STATE =
           ["@radix-ui/react-icons", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:1.3.0"],\
           ["@radix-ui/react-portal", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:1.0.4"],\
           ["@radix-ui/react-tabs", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:1.0.4"],\
-          ["@sentry/nextjs", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.91.0"],\
-          ["@sentry/utils", "npm:7.91.0"],\
           ["@storybook/addon-essentials", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.5.3"],\
           ["@storybook/addon-interactions", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.5.3"],\
           ["@storybook/addon-links", "virtual:74868250102727df59d0c08f1ddb6630e6cd48640d8ad9d1ed80f220eee5d95c37bdc80e67cbbd686a520d72c8276bea707c0a77572e4e760d1051e7254c23b3#npm:7.5.3"],\
@@ -12184,15 +11902,6 @@ const RAW_RUNTIME_STATE =
           ["ansi-styles", "npm:3.2.1"],\
           ["escape-string-regexp", "npm:1.0.5"],\
           ["supports-color", "npm:5.5.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.0.0", {\
-        "packageLocation": "./.yarn/cache/chalk-npm-3.0.0-e813208025-10c0.zip/node_modules/chalk/",\
-        "packageDependencies": [\
-          ["chalk", "npm:3.0.0"],\
-          ["ansi-styles", "npm:4.3.0"],\
-          ["supports-color", "npm:7.2.0"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -14551,15 +14260,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["estree-walker", [\
-      ["npm:2.0.2", {\
-        "packageLocation": "./.yarn/cache/estree-walker-npm-2.0.2-dfab42f65c-10c0.zip/node_modules/estree-walker/",\
-        "packageDependencies": [\
-          ["estree-walker", "npm:2.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["esutils", [\
       ["npm:2.0.3", {\
         "packageLocation": "./.yarn/cache/esutils-npm-2.0.3-f865beafd5-10c0.zip/node_modules/esutils/",\
@@ -15487,18 +15187,6 @@ const RAW_RUNTIME_STATE =
           ["path-is-absolute", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:8.1.0", {\
-        "packageLocation": "./.yarn/cache/glob-npm-8.1.0-65f64af8b1-10c0.zip/node_modules/glob/",\
-        "packageDependencies": [\
-          ["glob", "npm:8.1.0"],\
-          ["fs.realpath", "npm:1.0.0"],\
-          ["inflight", "npm:1.0.6"],\
-          ["inherits", "npm:2.0.4"],\
-          ["minimatch", "npm:5.1.6"],\
-          ["once", "npm:1.4.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["glob-parent", [\
@@ -15899,15 +15587,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:5.0.1", {\
-        "packageLocation": "./.yarn/cache/https-proxy-agent-npm-5.0.1-42d65f358e-10c0.zip/node_modules/https-proxy-agent/",\
-        "packageDependencies": [\
-          ["https-proxy-agent", "npm:5.0.1"],\
-          ["agent-base", "npm:6.0.2"],\
-          ["debug", "virtual:2f4f5d4be0c4271f81a756602d102e02c292a5b30d8b7f5dd19d5368d75df8bb2f1bf516e3f835c2b5501d1663eb437d4f00d6d057bcaee770b46e87267a0fa3#npm:4.3.4"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:7.0.2", {\
         "packageLocation": "./.yarn/cache/https-proxy-agent-npm-7.0.2-83ea6a5d42-10c0.zip/node_modules/https-proxy-agent/",\
         "packageDependencies": [\
@@ -16014,15 +15693,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["image-size", "npm:1.0.2"],\
           ["queue", "npm:6.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["immediate", [\
-      ["npm:3.0.6", {\
-        "packageLocation": "./.yarn/cache/immediate-npm-3.0.6-c27588a2d3-10c0.zip/node_modules/immediate/",\
-        "packageDependencies": [\
-          ["immediate", "npm:3.0.6"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16443,16 +16113,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/is-plain-object-npm-5.0.0-285b70faa3-10c0.zip/node_modules/is-plain-object/",\
         "packageDependencies": [\
           ["is-plain-object", "npm:5.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["is-reference", [\
-      ["npm:1.2.1", {\
-        "packageLocation": "./.yarn/cache/is-reference-npm-1.2.1-87ca1743c8-10c0.zip/node_modules/is-reference/",\
-        "packageDependencies": [\
-          ["is-reference", "npm:1.2.1"],\
-          ["@types/estree", "npm:1.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17576,16 +17236,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["lie", [\
-      ["npm:3.1.1", {\
-        "packageLocation": "./.yarn/cache/lie-npm-3.1.1-91350720d9-10c0.zip/node_modules/lie/",\
-        "packageDependencies": [\
-          ["lie", "npm:3.1.1"],\
-          ["immediate", "npm:3.0.6"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["lilconfig", [\
       ["npm:2.1.0", {\
         "packageLocation": "./.yarn/cache/lilconfig-npm-2.1.0-a179261924-10c0.zip/node_modules/lilconfig/",\
@@ -17684,16 +17334,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/loader-utils-npm-3.2.1-76ae2fd253-10c0.zip/node_modules/loader-utils/",\
         "packageDependencies": [\
           ["loader-utils", "npm:3.2.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["localforage", [\
-      ["npm:1.10.0", {\
-        "packageLocation": "./.yarn/cache/localforage-npm-1.10.0-cf9ea9a436-10c0.zip/node_modules/localforage/",\
-        "packageDependencies": [\
-          ["localforage", "npm:1.10.0"],\
-          ["lie", "npm:3.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17854,16 +17494,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/lz-string-npm-1.5.0-3860794e30-10c0.zip/node_modules/lz-string/",\
         "packageDependencies": [\
           ["lz-string", "npm:1.5.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["magic-string", [\
-      ["npm:0.27.0", {\
-        "packageLocation": "./.yarn/cache/magic-string-npm-0.27.0-a60a83c0b4-10c0.zip/node_modules/magic-string/",\
-        "packageDependencies": [\
-          ["magic-string", "npm:0.27.0"],\
-          ["@jridgewell/sourcemap-codec", "npm:1.4.15"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20892,16 +20522,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["rollup", [\
-      ["npm:2.78.0", {\
-        "packageLocation": "./.yarn/cache/rollup-npm-2.78.0-09284f4c78-10c0.zip/node_modules/rollup/",\
-        "packageDependencies": [\
-          ["rollup", "npm:2.78.0"],\
-          ["fsevents", "patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["run-applescript", [\
       ["npm:5.0.0", {\
         "packageLocation": "./.yarn/cache/run-applescript-npm-5.0.0-ea4b8840dd-10c0.zip/node_modules/run-applescript/",\
@@ -21451,16 +21071,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/stackframe-npm-1.3.4-bf4b7cc8fd-10c0.zip/node_modules/stackframe/",\
         "packageDependencies": [\
           ["stackframe", "npm:1.3.4"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["stacktrace-parser", [\
-      ["npm:0.1.10", {\
-        "packageLocation": "./.yarn/cache/stacktrace-parser-npm-0.1.10-36f3e571bd-10c0.zip/node_modules/stacktrace-parser/",\
-        "packageDependencies": [\
-          ["stacktrace-parser", "npm:0.1.10"],\
-          ["type-fest", "npm:0.7.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -22556,13 +22166,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/type-fest-npm-0.6.0-76b229965b-10c0.zip/node_modules/type-fest/",\
         "packageDependencies": [\
           ["type-fest", "npm:0.6.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:0.7.1", {\
-        "packageLocation": "./.yarn/cache/type-fest-npm-0.7.1-7b37912923-10c0.zip/node_modules/type-fest/",\
-        "packageDependencies": [\
-          ["type-fest", "npm:0.7.1"]\
         ],\
         "linkType": "HARD"\
       }],\

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { withSentryConfig } = require('@sentry/nextjs');
-
 const nextConfig = {
   reactStrictMode: true,
   images: {
@@ -62,14 +59,6 @@ const nextConfig = {
       },
     ],
   },
-  sentry: {
-    hideSourceMaps: true,
-  },
 };
 
-const sentryWebpackPluginOptions = {
-  silent: true,
-  authToken: process.env.NEXT_PUBLIC_SENTRY_AUTH_TOKEN,
-};
-
-module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-portal": "^1.0.4",
     "@radix-ui/react-tabs": "^1.0.4",
-    "@sentry/nextjs": "^7.91.0",
-    "@sentry/utils": "^7.91.0",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.8.4",
     "@toss/use-overlay": "^1.3.8",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,6 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,6 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,6 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -3,18 +3,6 @@ import localFont from 'next/font/local';
 export const pretendard = localFont({
   src: [
     {
-      path: '../assets/fonts/Pretendard/Pretendard-Thin.woff2',
-      weight: '100',
-    },
-    {
-      path: '../assets/fonts/Pretendard/Pretendard-ExtraLight.woff2',
-      weight: '200',
-    },
-    {
-      path: '../assets/fonts/Pretendard/Pretendard-Light.woff2',
-      weight: '300',
-    },
-    {
       path: '../assets/fonts/Pretendard/Pretendard-Regular.woff2',
       weight: '400',
     },
@@ -29,14 +17,6 @@ export const pretendard = localFont({
     {
       path: '../assets/fonts/Pretendard/Pretendard-Bold.woff2',
       weight: '700',
-    },
-    {
-      path: '../assets/fonts/Pretendard/Pretendard-ExtraBold.woff2',
-      weight: '800',
-    },
-    {
-      path: '../assets/fonts/Pretendard/Pretendard-Black.woff2',
-      weight: '900',
     },
   ],
   variable: '--font-pretendard',

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -2,13 +2,10 @@
 
 import { useEffect } from 'react';
 import NextError from 'next/error';
-import * as Sentry from '@sentry/nextjs';
 
 const GlobalError = ({ error }: { error: Error & { digest?: string } }) => {
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') return;
-
-    Sentry.captureException(error);
   }, [error]);
 
   return (

--- a/src/app/home/[username]/layout.tsx
+++ b/src/app/home/[username]/layout.tsx
@@ -1,8 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import type { Metadata } from 'next';
-import Image from 'next/image';
 
-import PurpleBlurImage from '@/assets/images/purple-blur.png';
 import { getMetadata } from '@/utils/getMetadata';
 
 import type { HomeRouteParams } from './page';
@@ -14,9 +12,7 @@ export const generateMetadata = async ({ params: { username } }: HomeRouteParams
 const HomeLayout = ({ children }: PropsWithChildren) => {
   return (
     <main className="relative flex justify-center bg-gradient1">
-      <div className="absolute right-0">
-        <Image src={PurpleBlurImage} width={390} height={125} alt="purple_blur" />
-      </div>
+      <div className="absolute right-0 w-full h-[125px] bg-gradientPurpleBlur" />
       <div className="w-full h-[100dvh]">
         <div className="w-full h-[100dvh] flex flex-col items-center justify-between pb-xs">{children}</div>
       </div>

--- a/src/app/home/[username]/layout.tsx
+++ b/src/app/home/[username]/layout.tsx
@@ -21,3 +21,5 @@ const HomeLayout = ({ children }: PropsWithChildren) => {
 };
 
 export default HomeLayout;
+
+export const runtime = 'edge';

--- a/src/components/atoms/lottie/Lottie.tsx
+++ b/src/components/atoms/lottie/Lottie.tsx
@@ -1,7 +1,9 @@
 import type { HTMLAttributes } from 'react';
 import { useEffect, useRef } from 'react';
 import type { AnimationConfig, AnimationItem } from 'lottie-web';
-import lottie from 'lottie-web';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+//@ts-ignore
+import lottie from 'lottie-web/build/player/lottie_light.min.js';
 
 interface LottieProps extends HTMLAttributes<HTMLDivElement>, Omit<AnimationConfig, 'container'> {
   src: string;

--- a/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
+++ b/src/features/home/components/MapCardCollections/EmptyMapCard/EmptyMapCard.tsx
@@ -37,7 +37,7 @@ export const EmptyMapCard = ({ alternativeTextIndex, position }: EmptyMapCardPro
   return (
     <button onClick={handleMapCardClick}>
       <MapCardLayout position={position} cursor="default">
-        <Image src={bandiboodiGray} width="100" height="100" alt="empty_goal" />
+        <Image src={bandiboodiGray} width="100" height="100" alt="empty_goal" priority />
         <Typography type="title5" className="text-gray-40 text-center text-ellipsis !whitespace-nowrap">
           {EMPTY_ALTERNATIVE_TEXTS[alternativeTextIndex]}
         </Typography>

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -2,11 +2,11 @@
 
 import type { RefObject } from 'react';
 import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { SwiperSlide } from 'swiper/react';
 
-import StarBg from '@/app/home/[username]/startBg';
 import { Avatar, ContentWrapper } from '@/components';
 import type { MemberProps } from '@/features/member/types';
 import type { GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
@@ -17,9 +17,10 @@ import { GOAL_COUNT_PER_PAGE, TOTAL_CURRENT_POSITIONS } from '../../constants';
 import { CurrentPositionCover } from '../currentPositionCover';
 import { MapCardPositioner } from '../mapCardPositioner';
 import { partitionArrayWithSmallerFirstGroup } from '../mapCardPositioner/MapCardPositioner.utils';
-import { MapSwiper } from '../mapSwiper';
 
-import LifeMapInfo from './LifeMapInfo';
+const StarBg = dynamic(() => import('@/app/home/[username]/startBg'));
+const LifeMapInfo = dynamic(() => import('./LifeMapInfo'));
+const MapSwiper = dynamic(() => import('../mapSwiper/MapSwiper'));
 
 interface LifeMapProps {
   goalsData?: GoalResponse;

--- a/src/features/home/components/lifeMap/PrivateLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PrivateLifeMap.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useRef } from 'react';
 import dynamic from 'next/dynamic';
 

--- a/src/features/home/components/lifeMap/PrivateLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PrivateLifeMap.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
-import Link from 'next/link';
-import { useOverlay } from '@toss/use-overlay';
+import { useRef } from 'react';
+import dynamic from 'next/dynamic';
 
-import { Button } from '@/components';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
 import { useGetGoals } from '@/hooks/reactQuery/goal/useGetGoals';
 
-import { ShareBottomSheet } from '../shareBottomSheet';
-import { ImageDownloadBottomSheet } from '../shareBottomSheet/ImageDownloadBottomSheet';
-import { ShareButton } from '../shareButton';
+const PrivateLifeMapBottomArea = dynamic(() => import('@/features/home/components/lifeMap/PrivateLifeMapBottomArea'));
 
 import { LifeMapContent } from './LifeMapContent';
 
@@ -19,31 +15,11 @@ export const PrivateLifeMap = () => {
   const { data: privateGoals } = useGetGoals();
 
   const downloadSectionRef = useRef<HTMLElement>(null);
-  const overlay = useOverlay();
-
-  const handleOpenShareBottomSheet = useCallback(() => {
-    overlay.open(({ isOpen, close }) => (
-      <ShareBottomSheet
-        open={isOpen}
-        onClose={close}
-        onClickImageDownload={() => {
-          overlay.open(({ isOpen, close }) => (
-            <ImageDownloadBottomSheet open={isOpen} onClose={close} ref={downloadSectionRef} />
-          ));
-        }}
-      />
-    ));
-  }, [overlay]);
 
   return (
     <>
       <LifeMapContent goalsData={privateGoals} memberData={memberData} downloadSectionRef={downloadSectionRef} />
-      <div className="flex gap-5xs px-xs pt-5xs mt-[18px] w-full">
-        <ShareButton onClick={handleOpenShareBottomSheet} />
-        <Link href={{ pathname: '/goal/new/goal' }} className="w-full">
-          <Button>목표 추가하기</Button>
-        </Link>
-      </div>
+      <PrivateLifeMapBottomArea downloadSectionRef={downloadSectionRef} />
     </>
   );
 };

--- a/src/features/home/components/lifeMap/PrivateLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PrivateLifeMapBottomArea.tsx
@@ -5,9 +5,8 @@ import { useOverlay } from '@toss/use-overlay';
 
 import { Button } from '@/components';
 
-import ImageDownloadBottomSheet from '../shareBottomSheet/ImageDownloadBottomSheet';
-import ShareBottomSheet from '../shareBottomSheet/ShareBottomSheet';
-import ShareButton from '../shareButton/ShareButton';
+import { ImageDownloadBottomSheet, ShareBottomSheet } from '../shareBottomSheet';
+import { ShareButton } from '../shareButton';
 
 interface PrivateLifeMapBottomAreaProps {
   downloadSectionRef?: RefObject<HTMLElement>;

--- a/src/features/home/components/lifeMap/PrivateLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PrivateLifeMapBottomArea.tsx
@@ -1,0 +1,43 @@
+import type { RefObject } from 'react';
+import { useCallback } from 'react';
+import Link from 'next/link';
+import { useOverlay } from '@toss/use-overlay';
+
+import { Button } from '@/components';
+
+import ImageDownloadBottomSheet from '../shareBottomSheet/ImageDownloadBottomSheet';
+import ShareBottomSheet from '../shareBottomSheet/ShareBottomSheet';
+import ShareButton from '../shareButton/ShareButton';
+
+interface PrivateLifeMapBottomAreaProps {
+  downloadSectionRef?: RefObject<HTMLElement>;
+}
+
+const PrivateLifeMapBottomArea = ({ downloadSectionRef }: PrivateLifeMapBottomAreaProps) => {
+  const overlay = useOverlay();
+
+  const handleOpenShareBottomSheet = useCallback(() => {
+    overlay.open(({ isOpen, close }) => (
+      <ShareBottomSheet
+        open={isOpen}
+        onClose={close}
+        onClickImageDownload={() => {
+          overlay.open(({ isOpen, close }) => (
+            <ImageDownloadBottomSheet open={isOpen} onClose={close} ref={downloadSectionRef} />
+          ));
+        }}
+      />
+    ));
+  }, [overlay]);
+
+  return (
+    <div className="flex gap-5xs px-xs pt-5xs mt-[18px] w-full">
+      <ShareButton onClick={handleOpenShareBottomSheet} />
+      <Link href={{ pathname: '/goal/new/goal' }} className="w-full">
+        <Button>목표 추가하기</Button>
+      </Link>
+    </div>
+  );
+};
+
+export default PrivateLifeMapBottomArea;

--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -1,77 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { useOverlay } from '@toss/use-overlay';
+import dynamic from 'next/dynamic';
 
-import { Button } from '@/components/atoms';
-import { CHEER_INTERVAL } from '@/constants';
-import { CheeringButton } from '@/features/cheering/CheeringButton';
-import { useThrottle } from '@/hooks';
-import { useGetMemberData } from '@/hooks/reactQuery/auth';
-import { useCreateCheering } from '@/hooks/reactQuery/cheering';
+const PublicLifeMapBottomArea = dynamic(() => import('@/features/home/components/lifeMap/PublicLifeMapBottomArea'));
+
 import { useGetPublicGoals } from '@/hooks/reactQuery/goal/useGetPublicGoals';
-import { useToast } from '@/hooks/useToast';
 
-import { LoginBottomSheet } from '../loginBottomSheet';
-
-import { CheeringClickedLottie } from './CheeringClicked';
 import { LifeMapContent } from './LifeMapContent';
 
 export const PublicLifeMap = ({ username }: { username: string }) => {
-  const { data: memberData } = useGetMemberData();
   const { data: publicGoals } = useGetPublicGoals({ username });
-
-  const { open } = useOverlay();
-  const toast = useToast();
-  const [isCheeringSuccess, setIsCheeringSuccess] = useState(false);
-
-  // TODO: Lottie atom을 수정해서 로티 이미지를 플레이하는 방식으로 변경
-  const { mutate: cheer, isSuccess } = useCreateCheering(username);
-
-  const CHEER_ANIMATION_INTERVAL = 5400;
-
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout | undefined;
-    if (isSuccess) {
-      setIsCheeringSuccess(true);
-      timeoutId = setTimeout(() => {
-        setIsCheeringSuccess(false);
-      }, CHEER_ANIMATION_INTERVAL);
-    }
-
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [isSuccess]);
-
-  const myHomePath = memberData?.username ? `/home/${memberData.username}` : '/';
-
-  const throttleCheer = useThrottle(() => cheer({ lifeMapId: publicGoals?.lifeMapId }), CHEER_INTERVAL);
-
-  const handleClickCheeringButton = () => {
-    if (!memberData?.nickname) {
-      open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
-      return;
-    }
-
-    if (!isCheeringSuccess) toast.warning('1분 뒤에 응원할 수 있어요.');
-
-    throttleCheer();
-  };
 
   return (
     <>
       <LifeMapContent isPublic goalsData={publicGoals} memberData={publicGoals?.user} />
-      {isCheeringSuccess && <CheeringClickedLottie />}
-      <div className="flex gap-5xs  px-xs pt-5xs mt-[18px] w-full z-[1]">
-        <CheeringButton onClick={handleClickCheeringButton} />
-        <Link href={{ pathname: myHomePath }} className="w-full">
-          <Button>{memberData?.username ? '내 지도로 돌아가기' : '로그인하기'}</Button>
-        </Link>
-      </div>
+      <PublicLifeMapBottomArea username={username} />
     </>
   );
 };

--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import dynamic from 'next/dynamic';
 
 const PublicLifeMapBottomArea = dynamic(() => import('@/features/home/components/lifeMap/PublicLifeMapBottomArea'));

--- a/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
@@ -4,7 +4,7 @@ import { useOverlay } from '@toss/use-overlay';
 
 import { Button } from '@/components';
 import { CHEER_INTERVAL } from '@/constants';
-import CheeringButton from '@/features/cheering/CheeringButton';
+import { CheeringButton } from '@/features/cheering/CheeringButton';
 import { useThrottle } from '@/hooks';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
 import { useCreateCheering } from '@/hooks/reactQuery/cheering';

--- a/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useOverlay } from '@toss/use-overlay';
+
+import { Button } from '@/components';
+import { CHEER_INTERVAL } from '@/constants';
+import CheeringButton from '@/features/cheering/CheeringButton';
+import { useThrottle } from '@/hooks';
+import { useGetMemberData } from '@/hooks/reactQuery/auth';
+import { useCreateCheering } from '@/hooks/reactQuery/cheering';
+import { useGetPublicGoals } from '@/hooks/reactQuery/goal/useGetPublicGoals';
+import { useToast } from '@/hooks/useToast';
+
+import { LoginBottomSheet } from '../loginBottomSheet';
+
+import { CheeringClickedLottie } from './CheeringClicked';
+
+const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
+  const { data: memberData } = useGetMemberData();
+  const { data: publicGoals } = useGetPublicGoals({ username });
+
+  const { open } = useOverlay();
+  const toast = useToast();
+
+  const [isCheeringSuccess, setIsCheeringSuccess] = useState(false);
+
+  // TODO: Lottie atom을 수정해서 로티 이미지를 플레이하는 방식으로 변경
+  const { mutate: cheer, isSuccess } = useCreateCheering(username);
+
+  const CHEER_ANIMATION_INTERVAL = 5400;
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | undefined;
+    if (isSuccess) {
+      setIsCheeringSuccess(true);
+      timeoutId = setTimeout(() => {
+        setIsCheeringSuccess(false);
+      }, CHEER_ANIMATION_INTERVAL);
+    }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [isSuccess]);
+
+  const myHomePath = memberData?.username ? `/home/${memberData.username}` : '/';
+
+  const throttleCheer = useThrottle(() => cheer({ lifeMapId: publicGoals?.lifeMapId }), CHEER_INTERVAL);
+
+  const handleClickCheeringButton = () => {
+    if (!memberData?.nickname) {
+      open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
+      return;
+    }
+
+    if (!isCheeringSuccess) toast.warning('1분 뒤에 응원할 수 있어요.');
+
+    throttleCheer();
+  };
+
+  return (
+    <>
+      {isCheeringSuccess && <CheeringClickedLottie />}
+      <div className="flex gap-5xs  px-xs pt-5xs mt-[18px] w-full z-[1]">
+        <CheeringButton onClick={handleClickCheeringButton} />
+        <Link href={{ pathname: myHomePath }} className="w-full">
+          <Button>{memberData?.username ? '내 지도로 돌아가기' : '로그인하기'}</Button>
+        </Link>
+      </div>
+    </>
+  );
+};
+
+export default PublicLifeMapBottomArea;

--- a/src/features/home/components/mapSwiper/MapSwiper.tsx
+++ b/src/features/home/components/mapSwiper/MapSwiper.tsx
@@ -17,7 +17,7 @@ interface MapSwiperProps {
   currentPage: number | null;
 }
 
-export const MapSwiper = ({ currentPage, children }: PropsWithChildren<MapSwiperProps>) => {
+const MapSwiper = ({ currentPage, children }: PropsWithChildren<MapSwiperProps>) => {
   return (
     currentPage !== null && (
       <Swiper {...settings} initialSlide={currentPage} className="h-full">
@@ -27,3 +27,5 @@ export const MapSwiper = ({ currentPage, children }: PropsWithChildren<MapSwiper
     )
   );
 };
+
+export default MapSwiper;

--- a/src/features/home/components/mapSwiper/index.ts
+++ b/src/features/home/components/mapSwiper/index.ts
@@ -1,1 +1,0 @@
-export { MapSwiper } from './MapSwiper';

--- a/src/features/home/components/shareBottomSheet/index.ts
+++ b/src/features/home/components/shareBottomSheet/index.ts
@@ -1,1 +1,2 @@
+export { ImageDownloadBottomSheet } from './ImageDownloadBottomSheet';
 export { ShareBottomSheet } from './ShareBottomSheet';

--- a/src/hooks/useDownloadImage.ts
+++ b/src/hooks/useDownloadImage.ts
@@ -1,5 +1,4 @@
 import { type RefObject, useState } from 'react';
-import * as Sentry from '@sentry/nextjs';
 import { domToJpeg } from 'modern-screenshot';
 
 import { GOAL_COUNT_PER_PAGE } from '@/features/home/constants';
@@ -67,7 +66,6 @@ export const useDownloadImage = ({ type, imageRef }: DownloadImageOption) => {
       downloadFile(imageUrl, IMAGE_FILE_NAME);
     } catch (error) {
       toast.warning('인생지도 다운로드에 실패했어요.');
-      Sentry.captureException(error);
     } finally {
       setIsDownloading(false);
     }

--- a/styles/theme/backgroundImage.ts
+++ b/styles/theme/backgroundImage.ts
@@ -7,4 +7,5 @@ export const backgroundImage = {
   gradient6: 'linear-gradient(233deg, rgba(200, 180, 255, 1) -50.9%, rgba(255, 255, 255, 0) 87.98%)',
   gradient7:
     'linear-gradient(180deg, rgba(169, 194, 220, 1) 0%, rgba(207, 223, 242, 1) 17.71%, rgba(203, 211, 221, 1) 54.17%, rgba(210, 216, 222, 1) 68.69%)',
+  gradientPurpleBlur: 'radial-gradient(129.59% 115.58% at 85.9% -33.6%, #C7C5FF 0%, #BBBBFF00 100%)',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,7 +2633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.13, @jridgewell/sourcemap-codec@npm:^1.4.14":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: 0c6b5ae663087558039052a626d2d7ed5208da36cfd707dcc5cea4a07cfc918248403dcb5989a8f7afaf245ce0573b7cc6fd94c4a30453bd10e44d9363940ba5
@@ -3662,224 +3662,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-commonjs@npm:24.0.0":
-  version: 24.0.0
-  resolution: "@rollup/plugin-commonjs@npm:24.0.0"
-  dependencies:
-    "@rollup/pluginutils": "npm:^5.0.1"
-    commondir: "npm:^1.0.1"
-    estree-walker: "npm:^2.0.2"
-    glob: "npm:^8.0.3"
-    is-reference: "npm:1.2.1"
-    magic-string: "npm:^0.27.0"
-  peerDependencies:
-    rollup: ^2.68.0||^3.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: ae2ed1d49722fad55f7ef7629baad5fb31bc389e6042912fb5cb9623c2c9c0def27c66bbd1aea72f1fcd65caa1410a9de80a0377f85d8cd8068f97c0adeaf3da
-  languageName: node
-  linkType: hard
-
-"@rollup/pluginutils@npm:^5.0.1":
-  version: 5.1.0
-  resolution: "@rollup/pluginutils@npm:5.1.0"
-  dependencies:
-    "@types/estree": "npm:^1.0.0"
-    estree-walker: "npm:^2.0.2"
-    picomatch: "npm:^2.3.1"
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: c7bed15711f942d6fdd3470fef4105b73991f99a478605e13d41888963330a6f9e32be37e6ddb13f012bc7673ff5e54f06f59fd47109436c1c513986a8a7612d
-  languageName: node
-  linkType: hard
-
 "@rushstack/eslint-patch@npm:^1.3.3":
   version: 1.5.1
   resolution: "@rushstack/eslint-patch@npm:1.5.1"
   checksum: bef32de80a93aebf3db8a2fcb408e2644918f4382bfd0851baf054cd0de3ece86bab3916d06798c236e0c951e3fc88e0921cd7edf89abb21b2418056ff9a3621
-  languageName: node
-  linkType: hard
-
-"@sentry-internal/feedback@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry-internal/feedback@npm:7.91.0"
-  dependencies:
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-  checksum: 32343a8334728167fa8f4304954b926990327e0593bad351c4408edf1108a3f74e126e82e3efd14c30443c1315979c3a123572513ed4f8fbfd04d15393d53f4c
-  languageName: node
-  linkType: hard
-
-"@sentry-internal/tracing@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry-internal/tracing@npm:7.91.0"
-  dependencies:
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-  checksum: 88970343e660e123a3653601f86034bc7433e6131500f8a9ccbfb524a4b3fe0cf1aa19bcf17904fd86091b6d48108d4edd29adc89edfcc46227c69d7c15b24a9
-  languageName: node
-  linkType: hard
-
-"@sentry/browser@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/browser@npm:7.91.0"
-  dependencies:
-    "@sentry-internal/feedback": "npm:7.91.0"
-    "@sentry-internal/tracing": "npm:7.91.0"
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/replay": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-  checksum: 6b895a479f0c48b78e6acb3fb75580b84c9b69ab58c8c4d603f9e7e361bedcee8f21f61aedf49a6ba33a23920373da9a0bea09cdc3647f37be2d01d076ba4f1e
-  languageName: node
-  linkType: hard
-
-"@sentry/cli@npm:^1.77.1":
-  version: 1.77.1
-  resolution: "@sentry/cli@npm:1.77.1"
-  dependencies:
-    https-proxy-agent: "npm:^5.0.0"
-    mkdirp: "npm:^0.5.5"
-    node-fetch: "npm:^2.6.7"
-    progress: "npm:^2.0.3"
-    proxy-from-env: "npm:^1.1.0"
-    which: "npm:^2.0.2"
-  bin:
-    sentry-cli: bin/sentry-cli
-  checksum: 92c9d9e26ca5667110a2546732c12d302753e76c47144103ca9d04d571f1933f4e0549b4b729a875dfafb1fbd071868b8b6c73855a581b8af07f39dee7636fcc
-  languageName: node
-  linkType: hard
-
-"@sentry/core@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/core@npm:7.91.0"
-  dependencies:
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-  checksum: a82eefd1f28e0e6d11cc0915e13412a359d5007e93dbad2b0bbbb60b06de2eba1fa624be86a0b5b9b2bab4b58be50fb903b3357b0cbd0c9c971683fb363ad3a2
-  languageName: node
-  linkType: hard
-
-"@sentry/integrations@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/integrations@npm:7.91.0"
-  dependencies:
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-    localforage: "npm:^1.8.1"
-  checksum: 9fc35825350f041fead8f0c5be410ea985140059ebcdd5ecd932287e1ab85d9dc792a0250a0f4e3c5b53c2fc059a0ab7d6c1af3e2bf5c2be3d61ddc4ea0f87dc
-  languageName: node
-  linkType: hard
-
-"@sentry/nextjs@npm:^7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/nextjs@npm:7.91.0"
-  dependencies:
-    "@rollup/plugin-commonjs": "npm:24.0.0"
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/integrations": "npm:7.91.0"
-    "@sentry/node": "npm:7.91.0"
-    "@sentry/react": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-    "@sentry/vercel-edge": "npm:7.91.0"
-    "@sentry/webpack-plugin": "npm:1.21.0"
-    chalk: "npm:3.0.0"
-    resolve: "npm:1.22.8"
-    rollup: "npm:2.78.0"
-    stacktrace-parser: "npm:^0.1.10"
-  peerDependencies:
-    next: ^10.0.8 || ^11.0 || ^12.0 || ^13.0 || ^14.0
-    react: 16.x || 17.x || 18.x
-    webpack: ">= 4.0.0"
-  peerDependenciesMeta:
-    webpack:
-      optional: true
-  checksum: 4c95d79af76d7284cfb01051775f992f535588b0fa929945a602d38224d4dfae1b7350e1aeb47a04b5415dc929ebccf709b1e66de6489acfb405e7f5b3a4d4d2
-  languageName: node
-  linkType: hard
-
-"@sentry/node@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/node@npm:7.91.0"
-  dependencies:
-    "@sentry-internal/tracing": "npm:7.91.0"
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-    https-proxy-agent: "npm:^5.0.0"
-  checksum: e360994c4d893ccb2f0f79a1290c928c8c7845cae2ce7374d183c13a1c0b4e71023f231cc658fb2b910faef89944a4a95cffa97b076d28c14c7a5bdcff2023de
-  languageName: node
-  linkType: hard
-
-"@sentry/react@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/react@npm:7.91.0"
-  dependencies:
-    "@sentry/browser": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-    hoist-non-react-statics: "npm:^3.3.2"
-  peerDependencies:
-    react: 15.x || 16.x || 17.x || 18.x
-  checksum: 9ac924a24b6461d58e9415aa26759abbb84fcd989c735a42145326ed728afbceb3f6c83fa0e796924b97a57592984f3bcc35d2cb7e0161e958eb4f542eff9c95
-  languageName: node
-  linkType: hard
-
-"@sentry/replay@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/replay@npm:7.91.0"
-  dependencies:
-    "@sentry-internal/tracing": "npm:7.91.0"
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-  checksum: 9f43347c2eaa24b634f4ee9882a13f437a71825ecd20f8d299c6f665d05516b5fc089ceb013849afdb7cff29edd02fed78c71db1139cf5e1fe3c0da6bcada0ec
-  languageName: node
-  linkType: hard
-
-"@sentry/types@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/types@npm:7.91.0"
-  checksum: 70c3698f8df877e9a55f8de99645d3caa15cea3249b5cf9290c78d44fd1c27b28cd3f07ec9ceb2a669400ddcb87dce4fefeca779092d46563a50c88e402eaf9d
-  languageName: node
-  linkType: hard
-
-"@sentry/utils@npm:7.91.0, @sentry/utils@npm:^7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/utils@npm:7.91.0"
-  dependencies:
-    "@sentry/types": "npm:7.91.0"
-  checksum: a8990cd46ec4493ab2122f0e804ee267ff99f534d299fbf59a04805c01d449636998105f655ca4e42d945a95969dc0da2807cc2b2ba88fdf806e2581ff115f45
-  languageName: node
-  linkType: hard
-
-"@sentry/vercel-edge@npm:7.91.0":
-  version: 7.91.0
-  resolution: "@sentry/vercel-edge@npm:7.91.0"
-  dependencies:
-    "@sentry-internal/tracing": "npm:7.91.0"
-    "@sentry/core": "npm:7.91.0"
-    "@sentry/types": "npm:7.91.0"
-    "@sentry/utils": "npm:7.91.0"
-  checksum: 282a579779fbb4fffdb6633fc6e23c834df40d315f161179310f5f1c8d57118e170b9a9248f02dca7210589b23503bc81cdd0211e9b6c7ab9e1d9410b44adbf4
-  languageName: node
-  linkType: hard
-
-"@sentry/webpack-plugin@npm:1.21.0":
-  version: 1.21.0
-  resolution: "@sentry/webpack-plugin@npm:1.21.0"
-  dependencies:
-    "@sentry/cli": "npm:^1.77.1"
-    webpack-sources: "npm:^2.0.0 || ^3.0.0"
-  checksum: 743650dc65c06c4a682d4e80ca2dee3234c30a2d5f66d2f9702e6e5041e20f6151a604fcc76d5f08afb6c7a91feec71719637916a5674fefd00fc1dda0560c7f
   languageName: node
   linkType: hard
 
@@ -6348,15 +6134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
-  dependencies:
-    debug: "npm:4"
-  checksum: dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.0.2, agent-base@npm:^7.1.0":
   version: 7.1.0
   resolution: "agent-base@npm:7.1.0"
@@ -6442,8 +6219,6 @@ __metadata:
     "@radix-ui/react-icons": "npm:^1.3.0"
     "@radix-ui/react-portal": "npm:^1.0.4"
     "@radix-ui/react-tabs": "npm:^1.0.4"
-    "@sentry/nextjs": "npm:^7.91.0"
-    "@sentry/utils": "npm:^7.91.0"
     "@storybook/addon-essentials": "npm:7.5.3"
     "@storybook/addon-interactions": "npm:7.5.3"
     "@storybook/addon-links": "npm:7.5.3"
@@ -7535,16 +7310,6 @@ __metadata:
   version: 2.4.0
   resolution: "case-sensitive-paths-webpack-plugin@npm:2.4.0"
   checksum: 310dab619b661a7fa44ed773870be6d6d7373faff6953ad92720f9553e2579e46dda5b9a79eae6d25ff3733cc15aa466b96e5811af16213f23c115aa220b4ab4
-  languageName: node
-  linkType: hard
-
-"chalk@npm:3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: ee650b0a065b3d7a6fda258e75d3a86fc8e4effa55871da730a9e42ccb035bf5fd203525e5a1ef45ec2582ecc4f65b47eb11357c526b84dd29a14fb162c414d2
   languageName: node
   linkType: hard
 
@@ -9519,13 +9284,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "estree-walker@npm:2.0.2"
-  checksum: 53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
-  languageName: node
-  linkType: hard
-
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -10377,19 +10135,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.3":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^5.0.1"
-    once: "npm:^1.3.0"
-  checksum: cb0b5cab17a59c57299376abe5646c7070f8acb89df5595b492dba3bfb43d301a46c01e5695f01154e6553168207cb60d4eaf07d3be4bc3eb9b0457c5c561d0f
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -10589,7 +10334,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -10717,16 +10462,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
-  dependencies:
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
-  languageName: node
-  linkType: hard
-
 "https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "https-proxy-agent@npm:7.0.2"
@@ -10816,13 +10551,6 @@ __metadata:
   bin:
     image-size: bin/image-size.js
   checksum: df518606c75d0ee12a6d7e822a64ef50d9eabbb303dcee8c9df06bad94e49b4d4680b9003968203f239ff39a9cc51d4ff1781cd331cc0a4b3b858d9fc9836c68
-  languageName: node
-  linkType: hard
-
-"immediate@npm:~3.0.5":
-  version: 3.0.6
-  resolution: "immediate@npm:3.0.6"
-  checksum: f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
   languageName: node
   linkType: hard
 
@@ -11189,15 +10917,6 @@ __metadata:
   dependencies:
     isobject: "npm:^3.0.1"
   checksum: f050fdd5203d9c81e8c4df1b3ff461c4bc64e8b5ca383bcdde46131361d0a678e80bcf00b5257646f6c636197629644d53bd8e2375aea633de09a82d57e942f4
-  languageName: node
-  linkType: hard
-
-"is-reference@npm:1.2.1":
-  version: 1.2.1
-  resolution: "is-reference@npm:1.2.1"
-  dependencies:
-    "@types/estree": "npm:*"
-  checksum: 7dc819fc8de7790264a0a5d531164f9f5b9ef5aa1cd05f35322d14db39c8a2ec78fd5d4bf57f9789f3ddd2b3abeea7728432b759636157a42db12a9e8c3b549b
   languageName: node
   linkType: hard
 
@@ -12174,15 +11893,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lie@npm:3.1.1":
-  version: 3.1.1
-  resolution: "lie@npm:3.1.1"
-  dependencies:
-    immediate: "npm:~3.0.5"
-  checksum: d62685786590351b8e407814acdd89efe1cb136f05cb9236c5a97b2efdca1f631d2997310ad2d565c753db7596799870140e4777c9c9b8c44a0f6bf42d1804a1
-  languageName: node
-  linkType: hard
-
 "lilconfig@npm:2.1.0, lilconfig@npm:^2.0.5, lilconfig@npm:^2.1.0":
   version: 2.1.0
   resolution: "lilconfig@npm:2.1.0"
@@ -12262,15 +11972,6 @@ __metadata:
   version: 3.2.1
   resolution: "loader-utils@npm:3.2.1"
   checksum: d3e1f217d160e8e894a0385a33500d4ce14065e8ffb250f5a81ae65bc2c3baa50625ec34182ba4417b46b4ac6725aed64429e1104d6401e074af2aa1dd018394
-  languageName: node
-  linkType: hard
-
-"localforage@npm:^1.8.1":
-  version: 1.10.0
-  resolution: "localforage@npm:1.10.0"
-  dependencies:
-    lie: "npm:3.1.1"
-  checksum: 00f19f1f97002e6721587ed5017f502d58faf80dae567d5065d4d1ee0caf0762f40d2e2dba7f0ef7d3f14ee6203242daae9ecad97359bfc10ecff36df11d85a3
   languageName: node
   linkType: hard
 
@@ -12422,15 +12123,6 @@ __metadata:
   bin:
     lz-string: bin/bin.js
   checksum: 36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.27.0":
-  version: 0.27.0
-  resolution: "magic-string@npm:0.27.0"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.4.13"
-  checksum: cddacfea14441ca57ae8a307bc3cf90bac69efaa4138dd9a80804cffc2759bf06f32da3a293fb13eaa96334b7d45b7768a34f1d226afae25d2f05b05a3bb37d8
   languageName: node
   linkType: hard
 
@@ -12823,7 +12515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.4, mkdirp@npm:^0.5.5":
+"mkdirp@npm:^0.5.4":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -13007,7 +12699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.0.0, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.0.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -14033,7 +13725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.1, progress@npm:^2.0.3":
+"progress@npm:^2.0.1":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: 1697e07cb1068055dbe9fe858d242368ff5d2073639e652b75a7eb1f2a1a8d4afd404d719de23c7b48481a6aa0040686310e2dac2f53d776daa2176d3f96369c
@@ -14810,7 +14502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:1.22.8, resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
+"resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -14836,7 +14528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -14943,20 +14635,6 @@ __metadata:
     hash-base: "npm:^3.0.0"
     inherits: "npm:^2.0.1"
   checksum: f6f0df78817e78287c766687aed4d5accbebc308a8e7e673fb085b9977473c1f139f0c5335d353f172a915bb288098430755d2ad3c4f30612f4dd0c901cd2c3a
-  languageName: node
-  linkType: hard
-
-"rollup@npm:2.78.0":
-  version: 2.78.0
-  resolution: "rollup@npm:2.78.0"
-  dependencies:
-    fsevents: "npm:~2.3.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 5bc5f0298f4c9eb9de0906c318cf396d24a32db0d1f21d46aaea04d4fad5c4a49c475cf49cde346bf3cb6ef5f0668d2451e83f96352639d186c3e34ef88f663e
   languageName: node
   linkType: hard
 
@@ -15445,15 +15123,6 @@ __metadata:
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
   checksum: 18410f7a1e0c5d211a4effa83bdbf24adbe8faa8c34db52e1cd3e89837518c592be60b60d8b7270ac53eeeb8b807cd11b399a41667f6c9abb41059c3ccc8a989
-  languageName: node
-  linkType: hard
-
-"stacktrace-parser@npm:^0.1.10":
-  version: 0.1.10
-  resolution: "stacktrace-parser@npm:0.1.10"
-  dependencies:
-    type-fest: "npm:^0.7.1"
-  checksum: f9c9cd55b0642a546e5f0516a87124fc496dcc2c082b96b156ed094c51e423314795cd1839cd4c59026349cf392d3414f54fc42165255602728588a58a9f72d3
   languageName: node
   linkType: hard
 
@@ -16295,13 +15964,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "type-fest@npm:0.7.1"
-  checksum: ce6b5ef806a76bf08d0daa78d65e61f24d9a0380bd1f1df36ffb61f84d14a0985c3a921923cf4b97831278cb6fa9bf1b89c751df09407e0510b14e8c081e4e0f
-  languageName: node
-  linkType: hard
-
 "type-fest@npm:^0.8.1":
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
@@ -16845,7 +16507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^2.0.0 || ^3.0.0, webpack-sources@npm:^3.2.3":
+"webpack-sources@npm:^3.2.3":
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
   checksum: 2ef63d77c4fad39de4a6db17323d75eb92897b32674e97d76f0a1e87c003882fc038571266ad0ef581ac734cbe20952912aaa26155f1905e96ce251adbb1eb4e
@@ -16971,7 +16633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1, which@npm:^2.0.2":
+"which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 인생 지도 페이지 성능 개선

## 🎉 어떻게 해결했나요?

### 측정 방법
pagespeed
   - [측정 결과 링크](https://pagespeed.web.dev/analysis/https-www-bandiboodi-com-home-newminkyung/11q1gs5exf?form_factor=mobile)
   
<img width="500" alt="image" src="https://github.com/depromeet/amazing3-fe/assets/80238096/e435e9fc-7c35-4255-b967-900ede23913e">

- 완전히 신뢰할 수 있는 지표는 아니지만 그래도 이건 좀 🚬
- 이거 돌려보고 살짝 충격받아서 간단한 작업만 진행해봤읍니다..

### 개선 방법
1. 불필요한 폰트 제거
    - 일부 font-weight만 쓰고 있어서 불필요한 폰트는 제거

| AS-IS | TO-BE |
|--------|--------|
| ![image](https://github.com/depromeet/amazing3-fe/assets/80238096/4298028e-2a7d-4634-b26b-93fdce33150f) | ![image](https://github.com/depromeet/amazing3-fe/assets/80238096/1a4cba6f-8291-47ee-a3d7-cd456cb46dd2) |
| 9개 | 5개 | 
 
2. purple blur 이미지 -> css 속성으로 변경

<img width="500" src="https://github.com/depromeet/amazing3-fe/assets/80238096/ad965461-390e-4643-9ece-1282fa4b2deb">

 
- 지도 페이지에서 제일 큰 컨텐츠가 purple blur 이미지
- css gradient 속성으로 변경

3. dynamic import 적용
    - 당장 보여야하는 컴포넌트를 제외하고는 dynamic import 적용
    -  지도 하단 버튼 영역에 dynamic import 적용

4. edge runtime 적용
    - node.js -> edge로 런타임 변경
    - 이 부분은 얼마나 빨라질지 모르겠지만 우선 적용해보았습니다

### 결과
| AS-IS | TO-BE |
|--------|--------|
| ![image](https://github.com/depromeet/amazing3-fe/assets/80238096/4a94c7f0-21ff-4042-8bc7-839cef55b8f7) | ![image](https://github.com/depromeet/amazing3-fe/assets/80238096/5850fc24-4030-4352-afce-f83b8984af9c) |

- 사이즈: `10.9kb` -> `6.7kb`
- js 사이즈: `375kb` -> `337kb`

### 📚 Attachment (Option)
- 빌드 깨진 부분은 살짝 스킵해주세요
   - 빌드 깨진 이유: 코드가 1MB가 넘으면 edge 런타임이 적용 안됨
   - 근데 지금 코드가 1.1MB
   - 다음 PR에서 번들 크기 줄여서 테스트해보고 .. 안되면 다시 node.js 런타임으로 변경할게욥~


