### PR TITLE
feat: 온보딩 생년월일 입력 optional로 변경

### DIFF
--- a/src/app/oauth2/token/page.tsx
+++ b/src/app/oauth2/token/page.tsx
@@ -21,7 +21,7 @@ const OAuthTokenPage = () => {
 
   useEffect(() => {
     if (isLoggedIn && memberData) {
-      router.push(memberData.birth ? `/home/${memberData.username}` : '/onboarding');
+      router.push(isLoggedIn ? `/home/${memberData.username}` : '/onboarding');
       localStorage.setItem('username', memberData.username);
     }
   }, [memberData, router, isLoggedIn]);

--- a/src/features/goal/components/new/DateInput.tsx
+++ b/src/features/goal/components/new/DateInput.tsx
@@ -11,7 +11,7 @@ import { formatDate, isValidDate } from '../../utils/date';
 interface DateInputProps {
   labelName?: string;
   intitalValue?: string;
-  maxLength: number;
+  maxLength?: number;
   onChange?: (value: string) => void;
 }
 

--- a/src/features/member/components/new/BirthInputForm.tsx
+++ b/src/features/member/components/new/BirthInputForm.tsx
@@ -6,9 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import BirthIcon from '@/assets/icons/birth-icon.svg';
 import { Button } from '@/components';
-import { MAX_DATE_LENGTH_UNTIL_DAY } from '@/constants';
 import { DateInput } from '@/features/goal/components/new/DateInput';
-import { useValidBirth } from '@/hooks/useValidBirth';
 
 import type { NewMemberFormValues } from '../../types';
 
@@ -19,7 +17,6 @@ export const BirthInputForm = () => {
   const { register, getValues, control } = useFormContext<NewMemberFormValues>();
   const { field } = useController({ name: 'birth', control });
   const { onChange, value } = field;
-  const isValidBirth = useValidBirth(value);
   const { nickname } = getValues();
 
   useEffect(() => {
@@ -37,11 +34,9 @@ export const BirthInputForm = () => {
       <div className="mt-xs flex flex-col grow w-full">
         <div className="w-full h-full flex flex-col justify-between">
           <div {...register('birth')}>
-            <DateInput maxLength={MAX_DATE_LENGTH_UNTIL_DAY} onChange={onChange} />
+            <DateInput onChange={onChange} />
           </div>
-          <Button type="submit" disabled={!isValidBirth}>
-            완료
-          </Button>
+          <Button type="submit">{value?.length ? '완료' : '건너뛰기'}</Button>
         </div>
       </div>
     </FormLayout>

--- a/src/features/member/contexts/NewMemberFormProvider.tsx
+++ b/src/features/member/contexts/NewMemberFormProvider.tsx
@@ -24,11 +24,11 @@ const NewMemberFormProvider = ({ children }: PropsWithChildren) => {
 
   const submit = (formData: NewMemberFormValues) => {
     const { nickname, birth } = formData;
-    if (!nickname || !birth) return;
+    if (!nickname) return;
 
     // Convert birth from "YYYY.MM.DD" to "YYYY-MM-DD"
     // TODO: 서버에서 YYYY.MM.DD 형식을 지원하면 이 부분 삭제
-    const convertedBirth = birth.replace(/\./g, '-');
+    const convertedBirth = birth?.replace(/\./g, '-');
 
     mutate({ ...formData, birth: convertedBirth });
   };

--- a/src/features/member/types/form.ts
+++ b/src/features/member/types/form.ts
@@ -1,6 +1,6 @@
 export interface NewMemberFormValues {
   nickname: string;
-  birth: string;
+  birth?: string;
 }
 
 export interface MemberProps {
@@ -8,7 +8,7 @@ export interface MemberProps {
   email: string;
   username: string;
   nickname: string;
-  birth: string;
+  birth?: string;
   image: string;
   createdAt: string;
   lifeMap: { isPublic: boolean; goalsCount: number; lifeMapId: number };

--- a/src/features/my/components/update/UpdateForm.tsx
+++ b/src/features/my/components/update/UpdateForm.tsx
@@ -85,7 +85,7 @@ export const UpdateForm = () => {
               <div {...register('birth')}>
                 <DateInput
                   labelName="생년월일"
-                  intitalValue={memberData.birth.replace(/\-/g, '.')}
+                  intitalValue={memberData.birth?.replace(/\-/g, '.')}
                   maxLength={MAX_DATE_LENGTH_UNTIL_DAY}
                   onChange={birthField.onChange}
                 />

--- a/src/features/my/components/userProfile/UserProfile.tsx
+++ b/src/features/my/components/userProfile/UserProfile.tsx
@@ -9,7 +9,7 @@ interface UserProfileProps {
   image: string;
   nickname: string;
   username: string;
-  birth: string;
+  birth?: string;
   email: string;
   subscriptionPeriod: number;
   goalCount: number;
@@ -20,7 +20,7 @@ const UserProfile = ({ image, nickname, username, birth, email, subscriptionPeri
     <div className="mt-md flex flex-col gap-lg items-center justify-center">
       <div className="flex flex-col gap-5xs items-center">
         <Avatar size={USER_PROFILE_IMAGE_SIZE} profileImage={image} />
-        <UserInfo nickname={nickname} birth={birth} username={username} email={email} />
+        <UserInfo nickname={nickname} birth={birth || ''} username={username} email={email} />
       </div>
       <ProfileCard days={subscriptionPeriod} totalGoals={goalCount} />
     </div>

--- a/src/features/my/types/form.ts
+++ b/src/features/my/types/form.ts
@@ -2,5 +2,5 @@ export interface UpdateMemberDataFormValues {
   image: string;
   nickname: string;
   username: string;
-  birth: string;
+  birth?: string;
 }

--- a/src/hooks/reactQuery/auth/useCreateMemberData.ts
+++ b/src/hooks/reactQuery/auth/useCreateMemberData.ts
@@ -4,7 +4,7 @@ import { api } from '@/apis';
 
 export interface MemberRequest {
   nickname: string;
-  birth: string;
+  birth?: string;
 }
 
 export const useCreateMemberData = () => {

--- a/src/hooks/useValidBirth.ts
+++ b/src/hooks/useValidBirth.ts
@@ -4,7 +4,7 @@ import { MAX_DATE_LENGTH_UNTIL_DAY } from '@/constants';
 
 import { useToast } from './useToast';
 
-export const useValidBirth = (value: string) => {
+export const useValidBirth = (value?: string) => {
   const toast = useToast();
   const [isValid, setIsValid] = useState(false);
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->


### 🚨~ 심사 통과하면 바로 원복시킬 예정입니다 🚨 ~

## 🤔 해결하려는 문제가 무엇인가요?
- 앱 심사 반려로 인해  온보딩 생년월일 입력을 optional로 변경합니다
   - [관련 스레드](https://depromeet14th.slack.com/archives/C0650S7UY5S/p1709768532315479)

## 🎉 어떻게 해결했나요?
- 생년월일 필드 optional로 변경
- 생년월일 입력하지 않을 시, 버튼 내용 `완료` -> `건너뛰기`로 수정

### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/80238096/c0af5f8a-de18-4cb9-aa22-cbd2f50d5edc



