### PR TITLE
fix: 프로필 수정 시, birth가 null일 경우 발생하는 오류 수정

### DIFF
--- a/src/features/my/components/update/UpdateForm.tsx
+++ b/src/features/my/components/update/UpdateForm.tsx
@@ -57,7 +57,7 @@ export const UpdateForm = () => {
       imageField.value.length === 0 ||
       nicknameField.value.length === 0 ||
       usernameField.value.length === 0 ||
-      birthField.value.length !== 10;
+      birthField.value?.length !== 10;
 
     setIsDisabledSubmit(isNotFilled || isNotModified || !isValidBirth);
   }, [memberData, imageField, nicknameField, birthField, usernameField, isValidBirth]);


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## ~~ 심사 후 원복 예정 ~~

## 🤔 해결하려는 문제가 무엇인가요?
- 프로필 수정 시, birth가 null일 경우 발생하는 오류 수정

## 🎉 어떻게 해결했나요?
- 온보딩에 생년월일을 입력하지 않은 사용자가 > 프로필 수정을 눌렀을 때 > birth가 null이기 때문에 오류 발생
-> 옵셔널 체이닝으로 수정

### 📚 Attachment (Option)
- 테스트 방법
  1. 온보딩에 생년월일 입력 x
  2. 프로필 이미지 클릭 후 수정 

