### PR TITLE
chore: 프로덕션일때만 sentry 에러 캐치하도록 수정

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,4 +3,5 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1.0,
+  enabled: process.env.NODE_ENV === 'production',
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,4 +3,5 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1.0,
+  enabled: process.env.NODE_ENV === 'production',
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,4 +3,5 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1.0,
+  enabled: process.env.NODE_ENV === 'production',
 });


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 프로덕션일때만 sentry 에러 캐치하도록 수정

## 🎉 어떻게 해결했나요?
- 프로덕션일때만 sentry 에러 캐치하도록 수정

### 📚 Attachment (Option)
- 

