### PR TITLE
fix: 무한스크롤 한 번 스크롤 시 페이지 여러개 요청하는 버그 수정

### DIFF
--- a/src/components/molecules/infiniteScroll/InfiniteScroller.tsx
+++ b/src/components/molecules/infiniteScroll/InfiniteScroller.tsx
@@ -1,26 +1,24 @@
-'use client';
-
 import type { PropsWithChildren } from 'react';
-import { useEffect, useRef } from 'react';
 
 import { Lottie } from '@/components/atoms/lottie';
 import { useIntersectionObserver } from '@/hooks';
 
 interface InfiniteScrollerProps extends PropsWithChildren {
   isLastPage: boolean;
-  onIntersected: (entry?: IntersectionObserverEntry) => void;
+  onIntersect: (entry?: IntersectionObserverEntry) => void;
 }
 
-export const InfiniteScroller = ({ onIntersected, isLastPage, children }: InfiniteScrollerProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const entry = useIntersectionObserver(ref, { threshold: 0.9 });
+export const InfiniteScroller = ({ onIntersect, isLastPage, children }: InfiniteScrollerProps) => {
+  const ref = useIntersectionObserver(
+    (entry, observer) => {
+      observer.unobserve(entry.target);
 
-  useEffect(() => {
-    if (!entry?.isIntersecting) return;
-    if (isLastPage) return;
+      if (isLastPage) return;
 
-    onIntersected(entry);
-  }, [entry, entry?.isIntersecting, onIntersected, isLastPage]);
+      onIntersect();
+    },
+    { threshold: 0.9 },
+  );
 
   return (
     <>

--- a/src/features/cheering/CheererList.tsx
+++ b/src/features/cheering/CheererList.tsx
@@ -2,6 +2,7 @@
 
 import { InfiniteScroller } from '@/components/molecules';
 import { useGetCheerer } from '@/hooks/reactQuery/cheering';
+import { generateId } from '@/utils/generateId';
 
 import { Cheerer } from './Cheerer';
 import { CheererCount } from './CheererCount';
@@ -16,10 +17,10 @@ export const CheererList = () => {
     <>
       <CheererCount count={cheererList?.pages[0].total} />
 
-      <InfiniteScroller isLastPage={!hasNextPage} onIntersected={() => fetchNextPage()}>
+      <InfiniteScroller isLastPage={!hasNextPage} onIntersect={() => fetchNextPage()}>
         <div className="flex flex-col gap-6xs mx-[24px] h-[calc(100dvh - 80px)]">
           {cheererList?.pages.map((page) =>
-            page.contents.map(({ ...props }) => <Cheerer key={`${props.userId}-${props.cheeringAt}`} {...props} />),
+            page.contents.map(({ ...props }) => <Cheerer key={generateId()} {...props} />),
           )}
         </div>
       </InfiniteScroller>

--- a/src/utils/generateId.ts
+++ b/src/utils/generateId.ts
@@ -1,0 +1,12 @@
+let idCounter = 0;
+/**
+ * 고유한 id 값을 생성하는 함수
+ *
+ * @param prefix
+ * @returns id
+ */
+export const generateId = (prefix = 'bandiboodi-id-') => {
+  idCounter = idCounter + 1;
+
+  return `${prefix}${idCounter}`;
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 무한스크롤 한 번 스크롤 시 여러번 요청하는 버그 수정

## 🎉 어떻게 해결했나요?
- 한 번 스크롤 시, 한 페이지만 요청해야하는데 페이지 여러개를 호출하는 버그 수정
   - Intersection Observer API 사용하는 커스텀 훅 수정 
- 키 값 중복 수정 
   - 탈퇴한 유저인 경우, 모든 응답 값이 똑같아서 키 중복 발생 
   - 고유한 아이디 값 생성하는 유틸 함수 추가

### 📚 Attachment (Option)
- 지능 떨어진채로 수정해서 제대로 동작 하지 않을 수도 .. 더 좋은 방법이 있을 수 있으니 많의부

