### PR TITLE
feat: 피드 페이지 댓글 바텀 시트 연결 / 리액션 기능 퍼블리싱

### DIFF
--- a/src/features/emoji/ReactionAddButton.tsx
+++ b/src/features/emoji/ReactionAddButton.tsx
@@ -9,7 +9,7 @@ interface ReactionAddButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
 export const ReactionAddButton = ({ isOpen, ...props }: ReactionAddButtonProps) => {
   return (
     <button
-      className={`w-fit h-fit rounded-full transition duration-300 hover:shadow-thumb hover:scale-105 transform ${
+      className={`w-fit h-fit rounded-full flex transition duration-300 hover:shadow-thumb hover:scale-105 transform ${
         isOpen ? 'rotate-45' : 'rotate-0'
       }`}
       {...props}

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -1,7 +1,10 @@
+import PlusIcon from '@/assets/icons/plus.svg';
 import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 
+import FeedCardBody from './FeedCardBody';
 import FeedCardHeader from './FeedCardHeader';
 import FeedCardLayout from './FeedCardLayout';
+import ViewCommentButton from './ViewCommentButton';
 
 interface FeedCardProps {
   feedData: Array<GoalFeedProps>;
@@ -20,7 +23,29 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
           goalCounts={count.goal}
         />
       }
-      bodyPropsList={feedData}
+      body={
+        <>
+          {feedData?.map(({ user, goal, count }) => (
+            <FeedCardBody
+              key={goal.id}
+              user={user}
+              goal={goal}
+              count={count}
+              interactionComponent={
+                <>
+                  {/* TODO: 이모지 추가 */}
+                  <div>
+                    <button className="w-[28px] h-[28px] flex justify-center items-center rounded-full bg-gradient3">
+                      <PlusIcon width={18} height={18} fill="#FFFFFF" />
+                    </button>
+                  </div>
+                  <ViewCommentButton numberOfComments={count.comment} />
+                </>
+              }
+            />
+          ))}
+        </>
+      }
     />
   );
 };

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -4,7 +4,7 @@ import { FeedCardBody } from './FeedCardBody';
 import { FeedCardHeader } from './FeedCardHeader';
 import { FeedCardLayout } from './FeedCardLayout';
 import { ReactionGroup } from './reactionGroup';
-import { ViewCommentButton } from './ViewCommentButton';
+import { CommentButton } from './ViewCommentButton';
 
 interface FeedCardProps {
   feedData: Array<GoalFeedProps>;
@@ -35,7 +35,7 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
                 <>
                   {/* TODO: 다른 유저가 이미 반응한 이모지 버튼 추가 */}
                   <ReactionGroup />
-                  <ViewCommentButton numberOfComments={count.comment} />
+                  <CommentButton numberOfComments={count.comment} />
                 </>
               }
             />

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -1,10 +1,10 @@
 import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 
-import FeedCardBody from './FeedCardBody';
-import FeedCardHeader from './FeedCardHeader';
-import FeedCardLayout from './FeedCardLayout';
+import { FeedCardBody } from './FeedCardBody';
+import { FeedCardHeader } from './FeedCardHeader';
+import { FeedCardLayout } from './FeedCardLayout';
 import { ReactionGroup } from './reactionGroup';
-import ViewCommentButton from './ViewCommentButton';
+import { ViewCommentButton } from './ViewCommentButton';
 
 interface FeedCardProps {
   feedData: Array<GoalFeedProps>;

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -31,7 +31,7 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
               user={user}
               goal={goal}
               count={count}
-              interactionComponent={
+              footer={
                 <>
                   {/* TODO: 다른 유저가 이미 반응한 이모지 버튼 추가 */}
                   <ReactionGroup />

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -1,9 +1,9 @@
-import PlusIcon from '@/assets/icons/plus.svg';
 import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 
 import FeedCardBody from './FeedCardBody';
 import FeedCardHeader from './FeedCardHeader';
 import FeedCardLayout from './FeedCardLayout';
+import { ReactionGroup } from './reactionGroup';
 import ViewCommentButton from './ViewCommentButton';
 
 interface FeedCardProps {
@@ -33,12 +33,8 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
               count={count}
               interactionComponent={
                 <>
-                  {/* TODO: 이모지 추가 */}
-                  <div>
-                    <button className="w-[28px] h-[28px] flex justify-center items-center rounded-full bg-gradient3">
-                      <PlusIcon width={18} height={18} fill="#FFFFFF" />
-                    </button>
-                  </div>
+                  {/* TODO: 다른 유저가 이미 반응한 이모지 버튼 추가 */}
+                  <ReactionGroup />
                   <ViewCommentButton numberOfComments={count.comment} />
                 </>
               }

--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -1,13 +1,14 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import CommentIcon from '@/assets/icons/comment-icon.svg';
 import PlusIcon from '@/assets/icons/plus.svg';
 import VerticalBarIcon from '@/assets/icons/vertical-bar.svg';
 import { Span, Typography } from '@/components';
 import { blueDataURL } from '@/constants';
 import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 import { formatDotYYYYMM } from '@/utils/date';
+
+import ViewCommentButton from './ViewCommentButton';
 
 interface FeedCardBodyProps extends GoalFeedProps {}
 
@@ -49,15 +50,7 @@ const FeedCardBody = ({ goal, count }: FeedCardBodyProps) => {
           <PlusIcon width={18} height={18} fill="#FFFFFF" />
         </button>
       </div>
-      {/* TODO: 댓글 페이지 이동 */}
-      <div>
-        <button className="flex gap-6xs items-center">
-          <CommentIcon />
-          <Typography type="title4" className="text-gray-40">
-            {count.comment > 0 ? `${count.comment}개의 댓글` : '댓글 작성하기'}
-          </Typography>
-        </button>
-      </div>
+      <ViewCommentButton numberOfComments={count.comment} />
     </div>
   );
 };

--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -12,7 +12,7 @@ interface FeedCardBodyProps extends GoalFeedProps {
   interactionComponent?: ReactNode;
 }
 
-const FeedCardBody = ({ goal, count, interactionComponent }: FeedCardBodyProps) => {
+export const FeedCardBody = ({ goal, count, interactionComponent }: FeedCardBodyProps) => {
   return (
     <div className="ml-lg flex flex-col gap-4xs">
       <Link href={{ pathname: `/goal/detail/${goal.id}` }}>
@@ -48,5 +48,3 @@ const FeedCardBody = ({ goal, count, interactionComponent }: FeedCardBodyProps) 
     </div>
   );
 };
-
-export default FeedCardBody;

--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -9,10 +9,10 @@ import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 import { formatDotYYYYMM } from '@/utils/date';
 
 interface FeedCardBodyProps extends GoalFeedProps {
-  interactionComponent?: ReactNode;
+  footer?: ReactNode;
 }
 
-export const FeedCardBody = ({ goal, count, interactionComponent }: FeedCardBodyProps) => {
+export const FeedCardBody = ({ goal, count, footer }: FeedCardBodyProps) => {
   return (
     <div className="ml-lg flex flex-col gap-4xs">
       <Link href={{ pathname: `/goal/detail/${goal.id}` }}>
@@ -44,7 +44,7 @@ export const FeedCardBody = ({ goal, count, interactionComponent }: FeedCardBody
           </div>
         </div>
       </Link>
-      {interactionComponent}
+      {footer}
     </div>
   );
 };

--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -1,18 +1,18 @@
+import type { ReactNode } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import PlusIcon from '@/assets/icons/plus.svg';
 import VerticalBarIcon from '@/assets/icons/vertical-bar.svg';
 import { Span, Typography } from '@/components';
 import { blueDataURL } from '@/constants';
 import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 import { formatDotYYYYMM } from '@/utils/date';
 
-import ViewCommentButton from './ViewCommentButton';
+interface FeedCardBodyProps extends GoalFeedProps {
+  interactionComponent?: ReactNode;
+}
 
-interface FeedCardBodyProps extends GoalFeedProps {}
-
-const FeedCardBody = ({ goal, count }: FeedCardBodyProps) => {
+const FeedCardBody = ({ goal, count, interactionComponent }: FeedCardBodyProps) => {
   return (
     <div className="ml-lg flex flex-col gap-4xs">
       <Link href={{ pathname: `/goal/detail/${goal.id}` }}>
@@ -44,13 +44,7 @@ const FeedCardBody = ({ goal, count }: FeedCardBodyProps) => {
           </div>
         </div>
       </Link>
-      {/* TODO: 이모지 추가 */}
-      <div>
-        <button className="w-[28px] h-[28px] flex justify-center items-center rounded-full bg-gradient3">
-          <PlusIcon width={18} height={18} fill="#FFFFFF" />
-        </button>
-      </div>
-      <ViewCommentButton numberOfComments={count.comment} />
+      {interactionComponent}
     </div>
   );
 };

--- a/src/features/feed/feedCard/FeedCardHeader.tsx
+++ b/src/features/feed/feedCard/FeedCardHeader.tsx
@@ -13,7 +13,13 @@ interface FeedCardHeaderProps {
   goalCounts: number;
 }
 
-const FeedCardHeader = ({ profileImage, nickname, username, goalCreatedTime, goalCounts }: FeedCardHeaderProps) => {
+export const FeedCardHeader = ({
+  profileImage,
+  nickname,
+  username,
+  goalCreatedTime,
+  goalCounts,
+}: FeedCardHeaderProps) => {
   return (
     <div className="flex justify-between items-center">
       <div className="flex gap-5xs">
@@ -38,5 +44,3 @@ const FeedCardHeader = ({ profileImage, nickname, username, goalCreatedTime, goa
     </div>
   );
 };
-
-export default FeedCardHeader;

--- a/src/features/feed/feedCard/FeedCardLayout.tsx
+++ b/src/features/feed/feedCard/FeedCardLayout.tsx
@@ -1,25 +1,17 @@
 import type { ReactNode } from 'react';
 
-import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
-
-import FeedCardBody from './FeedCardBody';
-
 interface FeedCardLayoutProps {
   header: ReactNode;
-  bodyPropsList: Array<GoalFeedProps>;
+  body: ReactNode;
 }
 
-const FeedCardLayout = ({ header, bodyPropsList }: FeedCardLayoutProps) => {
+const FeedCardLayout = ({ header, body }: FeedCardLayoutProps) => {
   return (
     <div className="flex flex-col gap-4xs">
       {header}
       <div className="relative">
         <div className="absolute top-0 left-3xs right-0 bottom-0 w-1 bg-gray-10 rounded-full" />
-        <div className="flex flex-col gap-sm">
-          {bodyPropsList?.map(({ user, goal, count }) => (
-            <FeedCardBody key={goal.id} user={user} goal={goal} count={count} />
-          ))}
-        </div>
+        <div className="flex flex-col gap-sm">{body}</div>
       </div>
     </div>
   );

--- a/src/features/feed/feedCard/FeedCardLayout.tsx
+++ b/src/features/feed/feedCard/FeedCardLayout.tsx
@@ -5,7 +5,7 @@ interface FeedCardLayoutProps {
   body: ReactNode;
 }
 
-const FeedCardLayout = ({ header, body }: FeedCardLayoutProps) => {
+export const FeedCardLayout = ({ header, body }: FeedCardLayoutProps) => {
   return (
     <div className="flex flex-col gap-4xs">
       {header}
@@ -16,5 +16,3 @@ const FeedCardLayout = ({ header, body }: FeedCardLayoutProps) => {
     </div>
   );
 };
-
-export default FeedCardLayout;

--- a/src/features/feed/feedCard/ViewCommentButton.tsx
+++ b/src/features/feed/feedCard/ViewCommentButton.tsx
@@ -1,0 +1,34 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { useOverlay } from '@toss/use-overlay';
+import { useAtomValue } from 'jotai';
+
+import CommentIcon from '@/assets/icons/comment-icon.svg';
+import { Typography } from '@/components';
+import { CommentsBottomSheet } from '@/features/comment';
+import { goalIdAtom } from '@/features/goal/atoms';
+
+interface CommentButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  numberOfComments: number;
+}
+
+export const ViewCommentButton = ({ numberOfComments, ...props }: CommentButtonProps) => {
+  const { open } = useOverlay();
+  const goalId = useAtomValue(goalIdAtom);
+
+  const handleOpenComments = () => {
+    open(({ isOpen, close }) => <CommentsBottomSheet open={isOpen} onClose={close} goalId={goalId} />);
+  };
+
+  return (
+    <div>
+      <button className="flex gap-6xs items-center" onClick={handleOpenComments} {...props}>
+        <CommentIcon />
+        <Typography type="title4" className="text-gray-40">
+          {numberOfComments > 0 ? `${numberOfComments}개의 댓글` : '댓글 작성하기'}
+        </Typography>
+      </button>
+    </div>
+  );
+};
+
+export default ViewCommentButton;

--- a/src/features/feed/feedCard/ViewCommentButton.tsx
+++ b/src/features/feed/feedCard/ViewCommentButton.tsx
@@ -30,5 +30,3 @@ export const ViewCommentButton = ({ numberOfComments, ...props }: CommentButtonP
     </div>
   );
 };
-
-export default ViewCommentButton;

--- a/src/features/feed/feedCard/ViewCommentButton.tsx
+++ b/src/features/feed/feedCard/ViewCommentButton.tsx
@@ -11,7 +11,7 @@ interface CommentButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   numberOfComments: number;
 }
 
-export const ViewCommentButton = ({ numberOfComments, ...props }: CommentButtonProps) => {
+export const CommentButton = ({ numberOfComments, ...props }: CommentButtonProps) => {
   const { open } = useOverlay();
   const goalId = useAtomValue(goalIdAtom);
 

--- a/src/features/feed/feedCard/reactionGroup/Emojis.tsx
+++ b/src/features/feed/feedCard/reactionGroup/Emojis.tsx
@@ -1,7 +1,7 @@
 import { EmojiGroup } from '@/components';
 
 // TODO: 모든 emoji를 받아오는 API로 수정 예정
-export const emojis = [
+export const emojisData = [
   {
     id: 1,
     url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
@@ -38,7 +38,7 @@ interface EmojisProps {
   onToggle: VoidFunction;
 }
 
-export const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
+export const Emojis = ({ onToggle }: EmojisProps) => {
   const handleReactEmoji = () => {
     // TODO: 리액션 추가하는 api
     onToggle();
@@ -46,7 +46,7 @@ export const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
 
   return (
     <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[16px] flex justify-center z-[2]">
-      {emojis.map((emoji) => (
+      {emojisData.map((emoji) => (
         <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji} />
       ))}
     </EmojiGroup.Container>

--- a/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
@@ -9,7 +9,7 @@ interface ReactedEmojiButtonProps extends ButtonHTMLAttributes<HTMLButtonElement
   isMyReaction: boolean;
 }
 
-const ReactedEmojiButton = ({ url, name, count, isMyReaction, ...props }: ReactedEmojiButtonProps) => {
+export const ReactedEmojiButton = ({ url, name, count, isMyReaction, ...props }: ReactedEmojiButtonProps) => {
   const [isClicked, setIsClicked] = useState(isMyReaction);
   const [currentCount, setCurrentCount] = useState(count);
 
@@ -34,5 +34,3 @@ const ReactedEmojiButton = ({ url, name, count, isMyReaction, ...props }: Reacte
     </button>
   );
 };
-
-export default ReactedEmojiButton;

--- a/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
@@ -1,6 +1,7 @@
 import { type ButtonHTMLAttributes, useState } from 'react';
 
 import { Emoji, Typography } from '@/components';
+import { formatOver999 } from '@/utils/number';
 
 interface ReactedEmojiButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   url: string;
@@ -29,7 +30,7 @@ export const ReactedEmojiButton = ({ url, name, count, isMyReaction, ...props }:
     >
       <Emoji url={url} size={24} name={name} />
       <Typography type="caption1" className={`${isClicked ? 'text-blue-50' : 'text-gray-40'}`}>
-        {currentCount > 999 ? '999+' : currentCount}
+        {formatOver999(currentCount)}
       </Typography>
     </button>
   );

--- a/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
@@ -1,0 +1,38 @@
+import { type ButtonHTMLAttributes, useState } from 'react';
+
+import { Emoji, Typography } from '@/components';
+
+interface ReactedEmojiButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  url: string;
+  name: string;
+  count: number;
+  isMyReaction: boolean;
+}
+
+const ReactedEmojiButton = ({ url, name, count, isMyReaction, ...props }: ReactedEmojiButtonProps) => {
+  const [isClicked, setIsClicked] = useState(isMyReaction);
+  const [currentCount, setCurrentCount] = useState(count);
+
+  const handleClickButton = () => {
+    setIsClicked((prev) => !prev);
+    setCurrentCount((prev) => (isClicked ? prev - 1 : prev + 1));
+    // TODO: isMyReaction에 따른 리액션 추가/취소 API 연결
+  };
+
+  return (
+    <button
+      className={`py-6xs px-5xs flex gap-6xs items-center rounded-full border box-border ${
+        isClicked ? 'bg-blue-10 border-blue-50' : 'bg-gray-10 border-white'
+      }`}
+      onClick={handleClickButton}
+      {...props}
+    >
+      <Emoji url={url} size={24} name={name} />
+      <Typography type="caption1" className={`${isClicked ? 'text-blue-50' : 'text-gray-40'}`}>
+        {currentCount > 999 ? '999+' : currentCount}
+      </Typography>
+    </button>
+  );
+};
+
+export default ReactedEmojiButton;

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 
 import { ReactionAddButton } from '@/features/emoji';
 
-import ReactedEmojiButton from './ReactedEmojiButton';
-import SelectReactionWindow, { emojis } from './SelectReactionWindow';
+import { ReactedEmojiButton } from './ReactedEmojiButton';
+import { emojis, SelectReactionWindow } from './SelectReactionWindow';
 
 // TODO: API 연결 후 삭제 예정
 const reactedEmojis = [

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -2,17 +2,17 @@ import { useState } from 'react';
 
 import { ReactionAddButton } from '@/features/emoji';
 
+import { Emojis, emojisData } from './Emojis';
 import { ReactedEmojiButton } from './ReactedEmojiButton';
-import { emojis, SelectReactionWindow } from './SelectReactionWindow';
 
 // TODO: API 연결 후 삭제 예정
 const reactedEmojis = [
-  { url: emojis[0].url, name: emojis[0].name, count: 3, isMyReaction: true },
-  { url: emojis[0].url, name: emojis[0].name, count: 27, isMyReaction: false },
-  { url: emojis[0].url, name: emojis[0].name, count: 123, isMyReaction: true },
-  { url: emojis[0].url, name: emojis[0].name, count: 12313, isMyReaction: true },
-  { url: emojis[0].url, name: emojis[0].name, count: 11, isMyReaction: false },
-  { url: emojis[0].url, name: emojis[0].name, count: 999, isMyReaction: false },
+  { url: emojisData[0].url, name: emojisData[0].name, count: 3, isMyReaction: true },
+  { url: emojisData[0].url, name: emojisData[0].name, count: 27, isMyReaction: false },
+  { url: emojisData[0].url, name: emojisData[0].name, count: 123, isMyReaction: true },
+  { url: emojisData[0].url, name: emojisData[0].name, count: 12313, isMyReaction: true },
+  { url: emojisData[0].url, name: emojisData[0].name, count: 11, isMyReaction: false },
+  { url: emojisData[0].url, name: emojisData[0].name, count: 999, isMyReaction: false },
 ];
 
 export const ReactionGroup = () => {
@@ -30,7 +30,7 @@ export const ReactionGroup = () => {
         ))}
         <ReactionAddButton isOpen={isOpenWindow} onClick={handleToggleWindow} />
       </div>
-      <div className="relative w-full">{isOpenWindow && <SelectReactionWindow onToggle={handleToggleWindow} />}</div>
+      <div className="relative w-full">{isOpenWindow && <Emojis onToggle={handleToggleWindow} />}</div>
     </>
   );
 };

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+import { ReactionAddButton } from '@/features/emoji';
+
+import SelectReactionWindow from './SelectReactionWindow';
+
+export const ReactionGroup = () => {
+  const [isOpenWindow, setOpenWindow] = useState(false);
+
+  const handleToggleWindow = () => setOpenWindow((prev) => !prev);
+
+  return (
+    <div>
+      <div className="relative">
+        {isOpenWindow && <SelectReactionWindow onToggle={handleToggleWindow} />}
+        <ReactionAddButton isOpen={isOpenWindow} onClick={handleToggleWindow} />
+      </div>
+    </div>
+  );
+};

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -2,19 +2,35 @@ import { useState } from 'react';
 
 import { ReactionAddButton } from '@/features/emoji';
 
-import SelectReactionWindow from './SelectReactionWindow';
+import ReactedEmojiButton from './ReactedEmojiButton';
+import SelectReactionWindow, { emojis } from './SelectReactionWindow';
+
+// TODO: API 연결 후 삭제 예정
+const reactedEmojis = [
+  { url: emojis[0].url, name: emojis[0].name, count: 3, isMyReaction: true },
+  { url: emojis[0].url, name: emojis[0].name, count: 27, isMyReaction: false },
+  { url: emojis[0].url, name: emojis[0].name, count: 123, isMyReaction: true },
+  { url: emojis[0].url, name: emojis[0].name, count: 12313, isMyReaction: true },
+  { url: emojis[0].url, name: emojis[0].name, count: 11, isMyReaction: false },
+  { url: emojis[0].url, name: emojis[0].name, count: 999, isMyReaction: false },
+];
 
 export const ReactionGroup = () => {
   const [isOpenWindow, setOpenWindow] = useState(false);
 
-  const handleToggleWindow = () => setOpenWindow((prev) => !prev);
+  const handleToggleWindow = () => {
+    setOpenWindow((prev) => !prev);
+  };
 
   return (
-    <div>
-      <div className="relative">
-        {isOpenWindow && <SelectReactionWindow onToggle={handleToggleWindow} />}
+    <>
+      <div className="w-full  flex flex-wrap gap-5xs items-center">
+        {reactedEmojis.map(({ url, name, count, isMyReaction }, idx) => (
+          <ReactedEmojiButton key={idx} url={url} name={name} count={count} isMyReaction={isMyReaction} />
+        ))}
         <ReactionAddButton isOpen={isOpenWindow} onClick={handleToggleWindow} />
       </div>
-    </div>
+      <div className="relative w-full">{isOpenWindow && <SelectReactionWindow onToggle={handleToggleWindow} />}</div>
+    </>
   );
 };

--- a/src/features/feed/feedCard/reactionGroup/SelectReactionWindow.tsx
+++ b/src/features/feed/feedCard/reactionGroup/SelectReactionWindow.tsx
@@ -1,7 +1,7 @@
 import { EmojiGroup } from '@/components';
 
 // TODO: 모든 emoji를 받아오는 API로 수정 예정
-const emojis = [
+export const emojis = [
   {
     id: 1,
     url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
@@ -45,7 +45,7 @@ const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
   };
 
   return (
-    <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[48px] flex justify-center z-[2]">
+    <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[16px] flex justify-center z-[2]">
       {emojis.map((emoji) => (
         <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji} />
       ))}

--- a/src/features/feed/feedCard/reactionGroup/SelectReactionWindow.tsx
+++ b/src/features/feed/feedCard/reactionGroup/SelectReactionWindow.tsx
@@ -38,7 +38,7 @@ interface EmojisProps {
   onToggle: VoidFunction;
 }
 
-const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
+export const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
   const handleReactEmoji = () => {
     // TODO: 리액션 추가하는 api
     onToggle();
@@ -52,5 +52,3 @@ const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
     </EmojiGroup.Container>
   );
 };
-
-export default SelectReactionWindow;

--- a/src/features/feed/feedCard/reactionGroup/SelectReactionWindow.tsx
+++ b/src/features/feed/feedCard/reactionGroup/SelectReactionWindow.tsx
@@ -1,0 +1,56 @@
+import { EmojiGroup } from '@/components';
+
+// TODO: 모든 emoji를 받아오는 API로 수정 예정
+const emojis = [
+  {
+    id: 1,
+    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
+    name: '좋아요',
+  },
+  {
+    id: 2,
+    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
+    name: '응원해요',
+  },
+  {
+    id: 3,
+    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
+    name: '놀라워요',
+  },
+  {
+    id: 4,
+    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
+    name: '열받아요',
+  },
+  {
+    id: 5,
+    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
+    name: '슬퍼요',
+  },
+  {
+    id: 6,
+    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
+    name: '대단해요',
+  },
+];
+
+interface EmojisProps {
+  onToggle: VoidFunction;
+}
+
+const SelectReactionWindow = ({ onToggle }: EmojisProps) => {
+  const handleReactEmoji = () => {
+    // TODO: 리액션 추가하는 api
+    onToggle();
+  };
+
+  return (
+    <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[48px] flex justify-center z-[2]">
+      {emojis.map((emoji) => (
+        <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji} />
+      ))}
+    </EmojiGroup.Container>
+  );
+};
+
+export default SelectReactionWindow;

--- a/src/features/feed/feedCard/reactionGroup/index.ts
+++ b/src/features/feed/feedCard/reactionGroup/index.ts
@@ -1,0 +1,1 @@
+export { ReactionGroup } from './ReactionGroup';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 피드 페이지의 피드 카드 기능 연결 및 퍼블리싱

## 🎉 어떻게 해결했나요?
- 피드 카드별 퍼블리싱된 댓글 바텀 시트 연결 및 리액션 기능 퍼블리싱
- 피드 카드 리팩토링

### 📚 Attachment (Option)

<img src="https://github.com/depromeet/amazing3-fe/assets/45158550/7e6ad923-6b02-4b89-a9d1-7e9d6302a62c" width="350" />

<img src="https://github.com/depromeet/amazing3-fe/assets/45158550/d566e6a1-687a-4a3f-a4c6-a71186f22413" width="350" />

- 아직 피드 API 에서 리액션쪽 구조가 안나와서 props가 아닌 테스트 데이터 형태로 집어넣어놨습니다 ㅠ
- 타임라인에서 재활용할 FeedCardLayout과 FeedCardBody를 molecule에 어떻게 넣을지 고민중..
- 나머지는 이제 앞으로 API 연결하면서 완성하면 끝일듯!
- 아 그리고 피드 페이지 무한 스크롤도 완료해서 적용만 하면 끝이라 민경센세 버그 수정 PR 들어가고 나서 PR 바로 올리겠슴다 🫡

