### PR TITLE
refactor: 이모지 관련 컴포넌트 중 필요한 모듈만 import하도록

### DIFF
--- a/src/features/emoji/BottomSheet/Content.tsx
+++ b/src/features/emoji/BottomSheet/Content.tsx
@@ -1,4 +1,4 @@
-import * as Tabs from '@radix-ui/react-tabs';
+import { Content as TabsContent } from '@radix-ui/react-tabs';
 
 import { ReactUser } from './ReactUser';
 
@@ -22,14 +22,14 @@ export const Content = ({ reactedEmojis }: ContentProps) => {
   return (
     <>
       {reactedEmojis.map((emoji) => (
-        <Tabs.Content value={emoji.name} key={emoji.id} className="px-xs pt-[13px]">
+        <TabsContent value={emoji.name} key={emoji.id} className="px-xs pt-[13px]">
           {emoji.reactUsers.map((user) => (
             <div key={emoji.id} className="pb-4xs">
               <ReactUser {...user} />
               <div className="h-[1px] bg-gray-20 mt-4xs" />
             </div>
           ))}
-        </Tabs.Content>
+        </TabsContent>
       ))}
     </>
   );

--- a/src/features/emoji/BottomSheet/Header.tsx
+++ b/src/features/emoji/BottomSheet/Header.tsx
@@ -1,4 +1,4 @@
-import * as Tabs from '@radix-ui/react-tabs';
+import { List as TabsList } from '@radix-ui/react-tabs';
 
 import { Emoji, Typography } from '@/components';
 import { addSuffixIfExceedsLimit } from '@/utils/suffix';
@@ -21,7 +21,7 @@ export const Header = ({ totalReactedEmojisCount, reactedEmojis }: HeaderProps) 
       <Typography type="body3" className="px-xs pt-5xs">
         총 {addSuffixIfExceedsLimit(totalReactedEmojisCount, 999)}개
       </Typography>
-      <Tabs.List className="flex items-center gap-4xs py-5xs overflow-scroll px-xs scrollbar-width-none">
+      <TabsList className="flex items-center gap-4xs py-5xs overflow-scroll px-xs scrollbar-width-none">
         {reactedEmojis.map((emoji) => (
           <Tab key={emoji.id} value={emoji.name}>
             <div className="flex gap-6xs items-center">
@@ -30,7 +30,7 @@ export const Header = ({ totalReactedEmojisCount, reactedEmojis }: HeaderProps) 
             </div>
           </Tab>
         ))}
-      </Tabs.List>
+      </TabsList>
     </div>
   );
 };

--- a/src/features/emoji/BottomSheet/ReactUserBottomSheet.tsx
+++ b/src/features/emoji/BottomSheet/ReactUserBottomSheet.tsx
@@ -1,4 +1,4 @@
-import * as Tabs from '@radix-ui/react-tabs';
+import { Root as TabsRoot } from '@radix-ui/react-tabs';
 
 import { BottomSheet } from '@/components';
 import { useGetEmojiByGoal } from '@/hooks/reactQuery/emoji';
@@ -18,10 +18,10 @@ export const ReactUserBottomSheet = ({ goalId, open, onClose }: ReactUserBottomS
   return (
     <BottomSheet open={open} onDismiss={onClose} fixedMaxHeight={450}>
       {data && (
-        <Tabs.Root>
+        <TabsRoot>
           <Header totalReactedEmojisCount={data?.totalReactedEmojisCount} reactedEmojis={data?.reactedEmojis} />
           <Content reactedEmojis={data.reactedEmojis} />
-        </Tabs.Root>
+        </TabsRoot>
       )}
     </BottomSheet>
   );


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 이모지 관련 컴포넌트 중 필요한 모듈만 import하도록 (`@radix-ui/react-tabs`)

## 🎉 어떻게 해결했나요?
- 필요한 모듈만 import

### 📚 Attachment (Option)
- N/A

