### PR TITLE
feat: 홈 화면 - 지도 탭 추가

### DIFF
--- a/src/app/home/[username]/layout.tsx
+++ b/src/app/home/[username]/layout.tsx
@@ -11,7 +11,7 @@ export const generateMetadata = async ({ params: { username } }: HomeRouteParams
 
 const HomeLayout = ({ children }: PropsWithChildren) => {
   return (
-    <main className="relative flex justify-center bg-gradient1">
+    <main className="relative flex justify-center">
       <div className="absolute right-0 w-full h-[125px] bg-gradientPurpleBlur" />
       <div className="w-full h-[100dvh]">
         <div className="w-full h-[100dvh] flex flex-col items-center justify-between">{children}</div>

--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 const MyLayout = ({ children }: PropsWithChildren) => {
-  return <div className="w-full h-[100dvh] bg-gradient1">{children}</div>;
+  return <div className="w-full h-[100dvh]">{children}</div>;
 };
 
 export default MyLayout;

--- a/src/features/home/components/homeTab/HomeTab.tsx
+++ b/src/features/home/components/homeTab/HomeTab.tsx
@@ -1,4 +1,4 @@
-import type { FC, SVGProps } from 'react';
+import type { Dispatch, FC, SetStateAction, SVGProps } from 'react';
 import { useState } from 'react';
 
 import { HomeTabMenu } from './HomeTabMenu';
@@ -11,7 +11,7 @@ interface TabMenu {
 
 interface HomeTabProps {
   tabList: TabMenu[];
-  onChangeActiveTab: (tab?: TabMenu) => void;
+  onChangeActiveTab: Dispatch<SetStateAction<TabMenu>>;
 }
 
 export const HomeTab = ({ tabList, onChangeActiveTab }: HomeTabProps) => {

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
-import { SwiperSlide } from 'swiper/react';
 
 import ActiveFeedMenuIcon from '@/assets/icons/home/feed-tab-active-icon.svg';
 import FeedMenuIcon from '@/assets/icons/home/feed-tab-default-icon.svg';
@@ -13,16 +11,12 @@ import MapMenuIcon from '@/assets/icons/home/map-tab-default-icon.svg';
 import { Avatar, ContentWrapper } from '@/components';
 import { FeedBody } from '@/features/feed';
 import type { MemberProps } from '@/features/member/types';
-import type { GoalProps, GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
-import { isLargerThanToday } from '@/utils/date';
+import type { GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
 
-import { GOAL_COUNT_PER_PAGE, TOTAL_CURRENT_POSITIONS } from '../../constants';
-import { CurrentPositionCover } from '../currentPositionCover';
 import { HomeTab } from '../homeTab/HomeTab';
-import { MapCardPositioner } from '../mapCardPositioner';
-import { partitionArrayWithSmallerFirstGroup } from '../mapCardPositioner/MapCardPositioner.utils';
-import MapSwiper from '../mapSwiper/MapSwiper';
 import { ShareButton } from '../shareButton';
+
+import { Map } from './Map';
 
 const StarBg = dynamic(() => import('@/app/home/[username]/startBg'));
 const LifeMapInfo = dynamic(() => import('./LifeMapInfo'));
@@ -50,55 +44,6 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
   const shareRef = useRef<HTMLElement>(null);
 
   const [tab, setTab] = useState(TAB_LIST[0]);
-
-  const participatedGoalsArray = partitionArrayWithSmallerFirstGroup(GOAL_COUNT_PER_PAGE, goalsData?.goals);
-  const LAST_PAGE = participatedGoalsArray.length;
-
-  const [positionState, setPositionState] = useState<PositionStateProps>({
-    position: null,
-    positionPage: null,
-  });
-  const [currentPage, setCurrentPage] = useState<number | null>(null);
-  const paramGoalId = Number(useSearchParams().get('id'));
-
-  useEffect(() => {
-    if (goalsData?.goals) {
-      findCurrentPosition(goalsData?.goals);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [goalsData]);
-
-  const findCurrentPosition = (goals: Array<GoalProps>) => {
-    const currentPosition = goals.findIndex(({ deadline }) => {
-      const [year, month] = deadline.split('.');
-      return isLargerThanToday(year, month);
-    });
-
-    let position;
-    switch (currentPosition) {
-      case -1: // goals이 아예 없는 경우를 제외하고 마지막 페이지로 이동
-        position = goals.length === 0 ? 1 : goals.length + 1;
-        break;
-      case 0: // 첫번째 페이지의 0 포지션은 1로 변경
-        position = 1;
-        break;
-      default:
-        position = currentPosition + 1;
-    }
-    const positionPage = Math.floor(position / GOAL_COUNT_PER_PAGE);
-    position = position % TOTAL_CURRENT_POSITIONS;
-    setPositionState({ position, positionPage });
-
-    let page = positionPage;
-    // check if query params contains id value
-    if (paramGoalId) {
-      const index = goals.findIndex(({ id: goalId }) => goalId === paramGoalId);
-      if (index > -1) {
-        page = Math.floor((index + 1) / GOAL_COUNT_PER_PAGE);
-      }
-    }
-    setCurrentPage(page);
-  };
 
   return (
     <div className={`flex justify-center w-full ${tab.name === 'MAP' ? 'bg-gradient1' : 'bg-white'}`}>
@@ -134,7 +79,7 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
           }
           ref={shareRef}
         >
-          <div className="flex h-[24px] mt-5xs">
+          <div className="flex h-[24px] items-center mt-5xs">
             <LifeMapInfo goalsData={goalsData} />
             <div className="absolute right-0">
               <HomeTab tabList={TAB_LIST} onChangeActiveTab={setTab} />
@@ -142,34 +87,7 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
           </div>
           <StarBg />
           <div className={`h-[520px] overflow-auto ${tab.name === 'FEED' ? 'mt-[16px] border-t border-blue-10' : ''}`}>
-            {tab.name === 'MAP' ? (
-              <div className="h-[520px]">
-                <div className="absolute inset-x-0">
-                  <MapSwiper currentPage={currentPage}>
-                    {participatedGoalsArray?.map((goals, page) => (
-                      <SwiperSlide key={`swiper-goal-${page}`}>
-                        {!(page % 2) ? (
-                          <MapCardPositioner
-                            type="A"
-                            goals={goals}
-                            isFirst={page === 0}
-                            isLast={page === LAST_PAGE - 1}
-                          />
-                        ) : (
-                          <MapCardPositioner type="B" goals={goals} isLast={page === LAST_PAGE - 1} />
-                        )}
-                        {/** 현재 위치에 별 위치 시키기 위해 1) 현재 날짜가 포함된 페이지를 찾아서, 2) 포지션 위치에 별을 출력함. */}
-                        {positionState.positionPage === page && positionState.position !== null && (
-                          <CurrentPositionCover currentPosition={positionState.position} />
-                        )}
-                      </SwiperSlide>
-                    ))}
-                  </MapSwiper>
-                </div>
-              </div>
-            ) : (
-              <FeedBody />
-            )}
+            {tab.name === 'MAP' ? <Map goalsData={goalsData} /> : <FeedBody />}
           </div>
         </ContentWrapper>
       </div>

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -9,7 +9,6 @@ import FeedMenuIcon from '@/assets/icons/home/feed-tab-default-icon.svg';
 import ActiveMapMenuIcon from '@/assets/icons/home/map-tab-active-icon.svg';
 import MapMenuIcon from '@/assets/icons/home/map-tab-default-icon.svg';
 import { Avatar, ContentWrapper } from '@/components';
-import { FeedBody } from '@/features/feed';
 import type { MemberProps } from '@/features/member/types';
 import type { GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
 
@@ -87,7 +86,7 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
           </div>
           <StarBg />
           <div className={`h-[520px] overflow-auto ${tab.name === 'FEED' ? 'mt-[16px] border-t border-blue-10' : ''}`}>
-            {tab.name === 'MAP' ? <Map goalsData={goalsData} /> : <FeedBody />}
+            {tab.name === 'MAP' ? <Map goalsData={goalsData} /> : <>타임라인</>}
           </div>
         </ContentWrapper>
       </div>

--- a/src/features/home/components/lifeMap/LifeMapInfo.tsx
+++ b/src/features/home/components/lifeMap/LifeMapInfo.tsx
@@ -33,7 +33,7 @@ const LifeMapInfo = ({ goalsData }: LifeMapInfoProps) => {
   };
 
   return (
-    <div className="flex items-center mt-4xs">
+    <div className="flex items-center">
       <>
         <div className="flex items-center">
           <StarIcon width={20} height={20} fill={colors.blue[30]} className="inline-block mr-[4px]" />
@@ -63,19 +63,3 @@ const LifeMapInfo = ({ goalsData }: LifeMapInfoProps) => {
 };
 
 export default LifeMapInfo;
-
-// TODO: animation 개선
-const initial = {
-  opacity: 0,
-  scale: 0.3,
-};
-
-const animate = {
-  opacity: 1,
-  scale: 1,
-};
-
-const transition = {
-  duration: 0.1,
-  scale: { type: 'spring', damping: 8, stiffness: 100, restDelta: 0.001 },
-};

--- a/src/features/home/components/lifeMap/Map.tsx
+++ b/src/features/home/components/lifeMap/Map.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { SwiperSlide } from 'swiper/react';
+
+import type { GoalProps, GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
+import { isLargerThanToday } from '@/utils/date';
+
+import { GOAL_COUNT_PER_PAGE, TOTAL_CURRENT_POSITIONS } from '../../constants';
+import { CurrentPositionCover } from '../currentPositionCover';
+import { MapCardPositioner } from '../mapCardPositioner';
+import { partitionArrayWithSmallerFirstGroup } from '../mapCardPositioner/MapCardPositioner.utils';
+import MapSwiper from '../mapSwiper/MapSwiper';
+
+interface PositionStateProps {
+  position: number | null;
+  positionPage: number | null;
+}
+
+export const Map = ({ goalsData }: { goalsData?: GoalResponse }) => {
+  const participatedGoalsArray = partitionArrayWithSmallerFirstGroup(GOAL_COUNT_PER_PAGE, goalsData?.goals);
+  const LAST_PAGE = participatedGoalsArray.length;
+
+  const [positionState, setPositionState] = useState<PositionStateProps>({
+    position: null,
+    positionPage: null,
+  });
+
+  const [currentPage, setCurrentPage] = useState<number | null>(null);
+  const paramGoalId = Number(useSearchParams().get('id'));
+
+  useEffect(() => {
+    if (goalsData?.goals) {
+      findCurrentPosition(goalsData?.goals);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [goalsData]);
+
+  const findCurrentPosition = (goals: Array<GoalProps>) => {
+    const currentPosition = goals.findIndex(({ deadline }) => {
+      const [year, month] = deadline.split('.');
+      return isLargerThanToday(year, month);
+    });
+
+    let position;
+    switch (currentPosition) {
+      case -1: // goals이 아예 없는 경우를 제외하고 마지막 페이지로 이동
+        position = goals.length === 0 ? 1 : goals.length + 1;
+        break;
+      case 0: // 첫번째 페이지의 0 포지션은 1로 변경
+        position = 1;
+        break;
+      default:
+        position = currentPosition + 1;
+    }
+    const positionPage = Math.floor(position / GOAL_COUNT_PER_PAGE);
+    position = position % TOTAL_CURRENT_POSITIONS;
+    setPositionState({ position, positionPage });
+
+    let page = positionPage;
+    // check if query params contains id value
+    if (paramGoalId) {
+      const index = goals.findIndex(({ id: goalId }) => goalId === paramGoalId);
+      if (index > -1) {
+        page = Math.floor((index + 1) / GOAL_COUNT_PER_PAGE);
+      }
+    }
+    setCurrentPage(page);
+  };
+
+  return (
+    <div className="absolute inset-x-0">
+      <MapSwiper currentPage={currentPage}>
+        {participatedGoalsArray?.map((goals, page) => (
+          <SwiperSlide key={`swiper-goal-${page}`}>
+            {!(page % 2) ? (
+              <MapCardPositioner type="A" goals={goals} isFirst={page === 0} isLast={page === LAST_PAGE - 1} />
+            ) : (
+              <MapCardPositioner type="B" goals={goals} isLast={page === LAST_PAGE - 1} />
+            )}
+            {/** 현재 위치에 별 위치 시키기 위해 1) 현재 날짜가 포함된 페이지를 찾아서, 2) 포지션 위치에 별을 출력함. */}
+            {positionState.positionPage === page && positionState.position !== null && (
+              <CurrentPositionCover currentPosition={positionState.position} />
+            )}
+          </SwiperSlide>
+        ))}
+      </MapSwiper>
+    </div>
+  );
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #218 

## 🎉 어떻게 해결했나요?
1.  지도 탭 / ~~피드 탭~~ 추가
2. 피드 탭 추가로 인해 `LifeMapContent` 컴포넌트가 복잡해져서 지도 탭에 해당하는 컴포넌트 분리했섭니다
   - `LifeMapContent` = 지도 탭 + 피드 탭
      - 추후에 기존에 있던 컴포넌트명 수정이 필요합니다.. 

https://github.com/depromeet/amazing3-fe/assets/80238096/21f735fc-f453-42d1-a5ea-2cbd7c13f6ef


### 📚 Attachment (Option)
#### TODO
- [ ] 홈 화면에 피드 탭이 추가되면서 LifeMap 관련 컴포넌트 이름 수정이 필요합니다..
- [ ] 홈 화면에 컨텐츠가 늘어나서 속도가 더 느려질 것 같은데 .. 성능 측정 후 개선이 필요할듯합니다..

