### PR TITLE
fix: 남 지도에서 공유 버튼을 -> 프로필 이미지로 변경

### DIFF
--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { SwiperSlide } from 'swiper/react';
 
-import { ContentWrapper } from '@/components';
+import { Avatar, ContentWrapper } from '@/components';
 import type { MemberProps } from '@/features/member/types';
 import type { GoalResponse } from '@/hooks/reactQuery/goal/useGetGoals';
 import { type GoalProps } from '@/hooks/reactQuery/goal/useGetGoals';
@@ -24,6 +25,7 @@ const MapSwiper = dynamic(() => import('../mapSwiper/MapSwiper'));
 interface LifeMapProps {
   goalsData?: GoalResponse;
   memberData?: Pick<MemberProps, 'nickname' | 'image'>;
+  isPublic?: boolean;
 }
 
 interface PositionStateProps {
@@ -31,7 +33,7 @@ interface PositionStateProps {
   positionPage: number | null;
 }
 
-export const LifeMapContent = ({ goalsData, memberData }: LifeMapProps) => {
+export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: LifeMapProps) => {
   const shareRef = useRef<HTMLElement>(null);
   const participatedGoalsArray = partitionArrayWithSmallerFirstGroup(GOAL_COUNT_PER_PAGE, goalsData?.goals);
   const LAST_PAGE = participatedGoalsArray.length;
@@ -85,7 +87,13 @@ export const LifeMapContent = ({ goalsData, memberData }: LifeMapProps) => {
   return (
     <div className="w-[390px] relative pt-xs">
       <span className="absolute right-[24px]">
-        <ShareButton shareRef={shareRef} />
+        {isPublic ? (
+          <Link href="/my" className="pointer-events-none">
+            <Avatar size={40} profileImage={memberData?.image} />
+          </Link>
+        ) : (
+          <ShareButton shareRef={shareRef} />
+        )}
       </span>
 
       <ContentWrapper

--- a/src/features/home/components/lifeMap/PublicLifeMap.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMap.tsx
@@ -11,7 +11,7 @@ export const PublicLifeMap = ({ username }: { username: string }) => {
 
   return (
     <>
-      <LifeMapContent goalsData={publicGoals} memberData={publicGoals?.user} />
+      <LifeMapContent isPublic goalsData={publicGoals} memberData={publicGoals?.user} />
       <PublicLifeMapBottomArea username={username} />
     </>
   );


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?

- 남의 지도에서 공유 버튼을 -> 프로필 이미지로 변경

## 🎉 어떻게 해결했나요?

https://github.com/depromeet/amazing3-fe/assets/80238096/76c3a712-f5f8-45cb-99d1-430b6ee5a8da

```
- 남의 지도: 프로필 이미지
- 내 지도: 공유 버튼
```

이 보이도록 수정

### 📚 Attachment (Option)
- dev에 한꺼번에 머지되면 LifeMapContent 컴포넌트 적절하게 분리하면 좋을 것 같습니다~

