### PR TITLE
fix: 응원한 사람 프로필 이미지 높이 깨지는 현상 수정

### DIFF
--- a/src/features/cheering/Cheerer.tsx
+++ b/src/features/cheering/Cheerer.tsx
@@ -15,7 +15,7 @@ export const Cheerer = ({ image, username, nickname, cheeredAt }: CheererProps) 
     <div className="flex items-center justify-between py-5xs">
       <Link href={`/home/${username}`}>
         <div className="flex items-center">
-          <Image src={image} alt="user-profile" width={32} height={32} className="rounded-full mr-5xs" />
+          <Image src={image} alt="user-profile" width={32} height={32} className="rounded-full mr-5xs max-h-[32px]" />
           <Typography type="body2">{nickname}</Typography>
         </div>
       </Link>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 응원한 사람 프로필 이미지 높이 깨지는 현상 수정
   - [관련 슬랙](https://depromeet14th.slack.com/archives/C064475K71C/p1710656693276839)

## 🎉 어떻게 해결했나요?

- 높이가 32px 보다 늘어나지 않도록 `max-height` 추가

| AS-IS | TO-BE |
|--------|--------|
| <img width="400" alt="스크린샷 2024-03-17 오후 3 48 16" src="https://github.com/depromeet/amazing3-fe/assets/80238096/ea60dd01-87cf-4c57-bbfa-1a8cc2903e08"> | <img width="520" alt="스크린샷 2024-03-17 오후 3 48 16" src="https://github.com/depromeet/amazing3-fe/assets/80238096/4a289c51-f9d0-44a6-b502-e5676c6dd851"> |



### 📚 Attachment (Option)
- 

