### PR TITLE
bug: 이모지 totalReactUserCount 값 추가 및 적용

### DIFF
--- a/src/features/goal/components/detail/emoji/Reaction.tsx
+++ b/src/features/goal/components/detail/emoji/Reaction.tsx
@@ -26,7 +26,7 @@ export const Reaction = () => {
       {data && (
         <>
           {!hasNoReactions && (
-            <ReactionUserTotalCount count={data.totalReactedEmojisCount} username={data.latestReactUserNickname} />
+            <ReactionUserTotalCount count={data.totalReactUserCount} username={data.latestReactUserNickname} />
           )}
           <div className={`relative flex gap-4xs items-center ${hasNoReactions && 'mt-sm'}`}>
             <ReactedEmojis reactedEmojis={data.reactedEmojis} onCloseEmojis={() => setOpenEmojis(false)} />

--- a/src/hooks/reactQuery/emoji/useGetEmojiByGoal.ts
+++ b/src/hooks/reactQuery/emoji/useGetEmojiByGoal.ts
@@ -8,6 +8,7 @@ type EmojiRequestParams = {
 
 export type EmojiResponse = {
   totalReactedEmojisCount: number;
+  totalReactUserCount: number;
   latestReactUserNickname: string;
   reactedEmojis: ReactedEmojisProps[];
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?

👇 한명이 모두 누른 이모지임에도, 총 이모지 개수로 count를 하고 있었어유

<img src="https://github.com/depromeet/amazing3-fe/assets/112946860/4a51b68e-fb1e-4661-9111-a0def05ad165" width="600" />


## 🎉 어떻게 해결했나요?
- 서버에서 `totalReactUserCount` 값 추가해줘서 적용했슴다

<img src="https://github.com/depromeet/amazing3-fe/assets/112946860/99acda4b-7003-448f-95c3-b71fd6c2a83e" width="600"/>

### 📚 Attachment (Option)

- 저 부분이 뭔가 클릭이 가능하다는 게 인지가 잘 안 되는 거 같아서
- 다원스에게 피그마로 알리긴 했는데, 다시한번 노티하구 변경되면 또 반영한 PR로 찾아올게유
