### PR TITLE
feat: 피드 페이지 API 연결

### DIFF
--- a/src/features/feed/FeedBody.tsx
+++ b/src/features/feed/FeedBody.tsx
@@ -18,8 +18,8 @@ export const FeedBody = () => {
         <InfiniteScroller isLastPage={!hasNextPage} onIntersect={() => fetchNextPage()}>
           <div className="mx-xs my-xs flex flex-col gap-md">
             {goalFeedsData?.pages.map(
-              (page) =>
-                createFeedDataGroupedByUser(page.goals)?.map((feedData) => {
+              ({ goals }) =>
+                createFeedDataGroupedByUser(goals)?.map((feedData) => {
                   const recentGoalId = feedData[0].goal.id;
                   return <FeedCard key={recentGoalId} feedData={feedData} />;
                 }),

--- a/src/features/feed/FeedBody.tsx
+++ b/src/features/feed/FeedBody.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { InfiniteScroller } from '@/components';
+import { usePrefetchAllEmoji } from '@/hooks/reactQuery/emoji/useGetAllEmoji';
 import { type GoalFeedProps, useGetGoalFeeds } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 
 import FeedCard from './feedCard/FeedCard';
 
 export const FeedBody = () => {
   const { data: goalFeedsData, fetchNextPage, hasNextPage } = useGetGoalFeeds();
+  usePrefetchAllEmoji();
 
   // TODO: 피드가 0개일 때, 처리 필요
 

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -12,6 +12,7 @@ interface FeedCardProps {
 
 const FeedCard = ({ feedData }: FeedCardProps) => {
   const { user, goal, count } = feedData[0];
+
   return (
     <FeedCardLayout
       header={
@@ -25,15 +26,14 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
       }
       body={
         <>
-          {feedData?.map(({ goal, count }) => (
+          {feedData?.map(({ goal, count, emojis }) => (
             <FeedCardBody
               key={goal.id}
               goal={goal}
               count={count}
               footer={
                 <>
-                  {/* TODO: 다른 유저가 이미 반응한 이모지 버튼 추가 */}
-                  <ReactionGroup />
+                  <ReactionGroup targetGoalId={goal.id} reactedEmojis={emojis} />
                   <CommentButton numberOfComments={count.comment} />
                 </>
               }

--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -25,10 +25,9 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
       }
       body={
         <>
-          {feedData?.map(({ user, goal, count }) => (
+          {feedData?.map(({ goal, count }) => (
             <FeedCardBody
               key={goal.id}
-              user={user}
               goal={goal}
               count={count}
               footer={

--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -5,10 +5,12 @@ import Link from 'next/link';
 import VerticalBarIcon from '@/assets/icons/vertical-bar.svg';
 import { Span, Typography } from '@/components';
 import { blueDataURL } from '@/constants';
-import type { GoalFeedProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
+import type { CountProps, GoalProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 import { formatDotYYYYMM } from '@/utils/date';
 
-interface FeedCardBodyProps extends GoalFeedProps {
+interface FeedCardBodyProps {
+  goal: GoalProps;
+  count: CountProps;
   footer?: ReactNode;
 }
 

--- a/src/features/feed/feedCard/reactionGroup/Emojis.tsx
+++ b/src/features/feed/feedCard/reactionGroup/Emojis.tsx
@@ -1,44 +1,13 @@
 import { EmojiGroup } from '@/components';
-
-// TODO: 모든 emoji를 받아오는 API로 수정 예정
-export const emojisData = [
-  {
-    id: 1,
-    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
-    name: '좋아요',
-  },
-  {
-    id: 2,
-    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
-    name: '응원해요',
-  },
-  {
-    id: 3,
-    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
-    name: '놀라워요',
-  },
-  {
-    id: 4,
-    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
-    name: '열받아요',
-  },
-  {
-    id: 5,
-    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
-    name: '슬퍼요',
-  },
-  {
-    id: 6,
-    url: 'https://github.com/depromeet/amazing3-fe/assets/112946860/3727715a-a778-4630-82b7-663662516ecc',
-    name: '대단해요',
-  },
-];
+import { useGetAllEmoji } from '@/hooks/reactQuery/emoji';
 
 interface EmojisProps {
   onToggle: VoidFunction;
 }
 
 export const Emojis = ({ onToggle }: EmojisProps) => {
+  const { data: emojisData } = useGetAllEmoji();
+
   const handleReactEmoji = () => {
     // TODO: 리액션 추가하는 api
     onToggle();
@@ -46,7 +15,7 @@ export const Emojis = ({ onToggle }: EmojisProps) => {
 
   return (
     <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[16px] flex justify-center z-[2]">
-      {emojisData.map((emoji) => (
+      {emojisData?.map((emoji) => (
         <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji} />
       ))}
     </EmojiGroup.Container>

--- a/src/features/feed/feedCard/reactionGroup/Emojis.tsx
+++ b/src/features/feed/feedCard/reactionGroup/Emojis.tsx
@@ -17,7 +17,7 @@ export const Emojis = ({ goalId, onToggle }: EmojisProps) => {
   };
 
   return (
-    <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[16px] flex justify-center z-[2]">
+    <EmojiGroup.Container className="absolute w-[330px] left-[-20px] right-0 transform -translate-y-1/2 top-[16px] flex justify-center z-[2]">
       {emojisData?.map((emoji) => (
         <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji(emoji.id)} />
       ))}

--- a/src/features/feed/feedCard/reactionGroup/Emojis.tsx
+++ b/src/features/feed/feedCard/reactionGroup/Emojis.tsx
@@ -1,22 +1,25 @@
 import { EmojiGroup } from '@/components';
 import { useGetAllEmoji } from '@/hooks/reactQuery/emoji';
+import { useCreateEmojiForFeed } from '@/hooks/reactQuery/emoji/useCreateEmojiForFeed';
 
 interface EmojisProps {
+  goalId: number;
   onToggle: VoidFunction;
 }
 
-export const Emojis = ({ onToggle }: EmojisProps) => {
+export const Emojis = ({ goalId, onToggle }: EmojisProps) => {
   const { data: emojisData } = useGetAllEmoji();
+  const { mutate } = useCreateEmojiForFeed();
 
-  const handleReactEmoji = () => {
-    // TODO: 리액션 추가하는 api
+  const handleReactEmoji = (emojiId: number) => () => {
+    mutate({ goalId, emojiId });
     onToggle();
   };
 
   return (
     <EmojiGroup.Container className="absolute left-0 right-0 transform -translate-y-1/2 top-[16px] flex justify-center z-[2]">
       {emojisData?.map((emoji) => (
-        <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji} />
+        <EmojiGroup.Emoji key={emoji.name} {...emoji} size={56} onClick={handleReactEmoji(emoji.id)} />
       ))}
     </EmojiGroup.Container>
   );

--- a/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
@@ -26,20 +26,18 @@ export const ReactedEmojiButton = ({
   ...props
 }: ReactedEmojiButtonProps) => {
   const [isClicked, setIsClicked] = useState(isMyReaction);
-  const [currentCount, setCurrentCount] = useState(count);
   const { mutate: createReactEmoji } = useCreateEmojiForFeed();
   const { mutate: deleteReactedEmoji } = useDeleteReactedEmojiForFeed();
 
   const handleClickButton = () => {
     setIsClicked((prev) => !prev);
-    setCurrentCount((prev) => (isClicked ? prev - 1 : prev + 1));
 
     isMyReaction ? deleteReactedEmoji({ goalId, emojiId }) : createReactEmoji({ goalId, emojiId });
 
     onCloseEmojis();
   };
 
-  if (currentCount <= 0) return null;
+  if (count <= 0) return null;
 
   return (
     <button
@@ -51,7 +49,7 @@ export const ReactedEmojiButton = ({
     >
       <Emoji url={url} size={24} name={name} />
       <Typography type="caption1" className={`${isClicked ? 'text-blue-50' : 'text-gray-40'}`}>
-        {formatOver999(currentCount)}
+        {formatOver999(count)}
       </Typography>
     </button>
   );

--- a/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
@@ -1,24 +1,45 @@
 import { type ButtonHTMLAttributes, useState } from 'react';
 
 import { Emoji, Typography } from '@/components';
+import { useCreateEmojiForFeed } from '@/hooks/reactQuery/emoji/useCreateEmojiForFeed';
+import { useDeleteReactedEmojiForFeed } from '@/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed';
 import { formatOver999 } from '@/utils/number';
 
 interface ReactedEmojiButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  goalId: number;
+  emojiId: number;
   url: string;
   name: string;
   count: number;
   isMyReaction: boolean;
+  onCloseEmojis: VoidFunction;
 }
 
-export const ReactedEmojiButton = ({ url, name, count, isMyReaction, ...props }: ReactedEmojiButtonProps) => {
+export const ReactedEmojiButton = ({
+  goalId,
+  emojiId,
+  url,
+  name,
+  count,
+  isMyReaction,
+  onCloseEmojis,
+  ...props
+}: ReactedEmojiButtonProps) => {
   const [isClicked, setIsClicked] = useState(isMyReaction);
   const [currentCount, setCurrentCount] = useState(count);
+  const { mutate: createReactEmoji } = useCreateEmojiForFeed();
+  const { mutate: deleteReactedEmoji } = useDeleteReactedEmojiForFeed();
 
   const handleClickButton = () => {
     setIsClicked((prev) => !prev);
     setCurrentCount((prev) => (isClicked ? prev - 1 : prev + 1));
-    // TODO: isMyReaction에 따른 리액션 추가/취소 API 연결
+
+    isMyReaction ? deleteReactedEmoji({ goalId, emojiId }) : createReactEmoji({ goalId, emojiId });
+
+    onCloseEmojis();
   };
+
+  if (currentCount <= 0) return null;
 
   return (
     <button

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -22,10 +22,10 @@ interface ReactionGroupProps {
 }
 
 export const ReactionGroup = ({ targetGoalId, reactedEmojis }: ReactionGroupProps) => {
-  const [isOpenWindow, setOpenWindow] = useState(false);
+  const [isOpenEmojis, setOpenEmojis] = useState(false);
 
-  const handleToggleWindow = () => {
-    setOpenWindow((prev) => !prev);
+  const handleToggleEmojis = () => {
+    setOpenEmojis((prev) => !prev);
   };
   const handleClickEmojiButton = (emojiId: number) => {
     // TODO: 이모지 API 연결 (임시 console)
@@ -47,9 +47,9 @@ export const ReactionGroup = ({ targetGoalId, reactedEmojis }: ReactionGroupProp
             }}
           />
         ))}
-        <ReactionAddButton isOpen={isOpenWindow} onClick={handleToggleWindow} />
+        <ReactionAddButton isOpen={isOpenEmojis} onClick={handleToggleEmojis} />
       </div>
-      <div className="relative w-full">{isOpenWindow && <Emojis onToggle={handleToggleWindow} />}</div>
+      <div className="relative w-full">{isOpenEmojis && <Emojis onToggle={handleToggleEmojis} />}</div>
     </>
   );
 };

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -17,9 +17,8 @@ export const ReactionGroup = ({ targetGoalId, reactedEmojis }: ReactionGroupProp
   const handleToggleEmojis = () => {
     setOpenEmojis((prev) => !prev);
   };
-  const handleClickEmojiButton = (emojiId: number) => {
-    // TODO: 이모지 API 연결 (임시 console)
-    console.log(targetGoalId, emojiId);
+  const handleCloseEmojis = () => {
+    () => setOpenEmojis(false);
   };
 
   return (
@@ -28,18 +27,20 @@ export const ReactionGroup = ({ targetGoalId, reactedEmojis }: ReactionGroupProp
         {reactedEmojis.map(({ id, url, name, reactCount, isMyReaction }) => (
           <ReactedEmojiButton
             key={id}
+            goalId={targetGoalId}
+            emojiId={id}
             url={url}
             name={name}
             count={reactCount}
             isMyReaction={isMyReaction}
-            onClick={() => {
-              handleClickEmojiButton(id);
-            }}
+            onCloseEmojis={handleCloseEmojis}
           />
         ))}
         <ReactionAddButton isOpen={isOpenEmojis} onClick={handleToggleEmojis} />
       </div>
-      <div className="relative w-full">{isOpenEmojis && <Emojis onToggle={handleToggleEmojis} />}</div>
+      <div className="relative w-full">
+        {isOpenEmojis && <Emojis goalId={targetGoalId} onToggle={handleToggleEmojis} />}
+      </div>
     </>
   );
 };

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -37,9 +37,9 @@ export const ReactionGroup = ({ targetGoalId, reactedEmojis }: ReactionGroupProp
           />
         ))}
         <ReactionAddButton isOpen={isOpenEmojis} onClick={handleToggleEmojis} />
-      </div>
-      <div className="relative w-full">
-        {isOpenEmojis && <Emojis goalId={targetGoalId} onToggle={handleToggleEmojis} />}
+        <div className="relative w-full">
+          {isOpenEmojis && <Emojis goalId={targetGoalId} onToggle={handleToggleEmojis} />}
+        </div>
       </div>
     </>
   );

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -1,32 +1,51 @@
 import { useState } from 'react';
 
 import { ReactionAddButton } from '@/features/emoji';
+import type { EmojisProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 
-import { Emojis, emojisData } from './Emojis';
+import { Emojis } from './Emojis';
 import { ReactedEmojiButton } from './ReactedEmojiButton';
 
 // TODO: API 연결 후 삭제 예정
-const reactedEmojis = [
-  { url: emojisData[0].url, name: emojisData[0].name, count: 3, isMyReaction: true },
-  { url: emojisData[0].url, name: emojisData[0].name, count: 27, isMyReaction: false },
-  { url: emojisData[0].url, name: emojisData[0].name, count: 123, isMyReaction: true },
-  { url: emojisData[0].url, name: emojisData[0].name, count: 12313, isMyReaction: true },
-  { url: emojisData[0].url, name: emojisData[0].name, count: 11, isMyReaction: false },
-  { url: emojisData[0].url, name: emojisData[0].name, count: 999, isMyReaction: false },
-];
+// const reactedEmojis = [
+//   { url: emojisData[0].url, name: emojisData[0].name, count: 3, isMyReaction: true },
+//   { url: emojisData[0].url, name: emojisData[0].name, count: 27, isMyReaction: false },
+//   { url: emojisData[0].url, name: emojisData[0].name, count: 123, isMyReaction: true },
+//   { url: emojisData[0].url, name: emojisData[0].name, count: 12313, isMyReaction: true },
+//   { url: emojisData[0].url, name: emojisData[0].name, count: 11, isMyReaction: false },
+//   { url: emojisData[0].url, name: emojisData[0].name, count: 999, isMyReaction: false },
+// ];
 
-export const ReactionGroup = () => {
+interface ReactionGroupProps {
+  targetGoalId: number;
+  reactedEmojis: Array<EmojisProps>;
+}
+
+export const ReactionGroup = ({ targetGoalId, reactedEmojis }: ReactionGroupProps) => {
   const [isOpenWindow, setOpenWindow] = useState(false);
 
   const handleToggleWindow = () => {
     setOpenWindow((prev) => !prev);
   };
+  const handleClickEmojiButton = (emojiId: number) => {
+    // TODO: 이모지 API 연결 (임시 console)
+    console.log(targetGoalId, emojiId);
+  };
 
   return (
     <>
       <div className="w-full  flex flex-wrap gap-5xs items-center">
-        {reactedEmojis.map(({ url, name, count, isMyReaction }, idx) => (
-          <ReactedEmojiButton key={idx} url={url} name={name} count={count} isMyReaction={isMyReaction} />
+        {reactedEmojis.map(({ id, url, name, reactCount, isMyReaction }) => (
+          <ReactedEmojiButton
+            key={id}
+            url={url}
+            name={name}
+            count={reactCount}
+            isMyReaction={isMyReaction}
+            onClick={() => {
+              handleClickEmojiButton(id);
+            }}
+          />
         ))}
         <ReactionAddButton isOpen={isOpenWindow} onClick={handleToggleWindow} />
       </div>

--- a/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactionGroup.tsx
@@ -6,16 +6,6 @@ import type { EmojisProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 import { Emojis } from './Emojis';
 import { ReactedEmojiButton } from './ReactedEmojiButton';
 
-// TODO: API 연결 후 삭제 예정
-// const reactedEmojis = [
-//   { url: emojisData[0].url, name: emojisData[0].name, count: 3, isMyReaction: true },
-//   { url: emojisData[0].url, name: emojisData[0].name, count: 27, isMyReaction: false },
-//   { url: emojisData[0].url, name: emojisData[0].name, count: 123, isMyReaction: true },
-//   { url: emojisData[0].url, name: emojisData[0].name, count: 12313, isMyReaction: true },
-//   { url: emojisData[0].url, name: emojisData[0].name, count: 11, isMyReaction: false },
-//   { url: emojisData[0].url, name: emojisData[0].name, count: 999, isMyReaction: false },
-// ];
-
 interface ReactionGroupProps {
   targetGoalId: number;
   reactedEmojis: Array<EmojisProps>;

--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/apis';
+
+type EmojiRequestParams = {
+  goalId: number;
+  emojiId: number;
+};
+
+export const useCreateEmojiForFeed = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.post(`/goal/${goalId}/emoji/${emojiId}`),
+    onSuccess: (_, { goalId }) => {
+      queryClient.invalidateQueries({ queryKey: ['goalFeeds'] });
+      queryClient.invalidateQueries({ queryKey: ['emoji', goalId] });
+    },
+  });
+};

--- a/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/apis';
+
+type EmojiRequestParams = {
+  goalId: number;
+  emojiId: number;
+};
+
+export const useDeleteReactedEmojiForFeed = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.delete(`/goal/${goalId}/emoji/${emojiId}`),
+    onSuccess: (_, { goalId }) => {
+      queryClient.invalidateQueries({ queryKey: ['goalFeeds'] });
+      queryClient.invalidateQueries({ queryKey: ['emoji', goalId] });
+    },
+  });
+};

--- a/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
+++ b/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
@@ -2,7 +2,30 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 
-type FeedEmojis = {
+export type UserProps = {
+  id: number;
+  nickname: string;
+  username: string;
+  image: string;
+};
+
+export type GoalProps = {
+  id: number;
+  title: string;
+  description: string;
+  deadline: string;
+  sticker: string;
+  tag: string;
+  createdAt: string;
+};
+export type CountProps = {
+  reaction: number;
+  comment: number;
+  task: number;
+  goal: number;
+};
+
+export type EmojisProps = {
   id: number;
   name: string;
   url: string;
@@ -11,28 +34,10 @@ type FeedEmojis = {
 };
 
 export type GoalFeedProps = {
-  user: {
-    id: number;
-    nickname: string;
-    username: string;
-    image: string;
-  };
-  goal: {
-    id: number;
-    title: string;
-    description: string;
-    deadline: string;
-    sticker: string;
-    tag: string;
-    createdAt: string;
-  };
-  count: {
-    reaction: number;
-    comment: number;
-    task: number;
-    goal: number;
-  };
-  emojis: Array<FeedEmojis>;
+  user: UserProps;
+  goal: GoalProps;
+  count: CountProps;
+  emojis: Array<EmojisProps>;
 };
 
 export type GoalFeedResponse = {

--- a/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
+++ b/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
@@ -2,6 +2,14 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 
+type FeedEmojis = {
+  id: number;
+  name: string;
+  url: string;
+  reactCount: number;
+  isMyReaction: boolean;
+};
+
 export type GoalFeedProps = {
   user: {
     id: number;
@@ -24,6 +32,7 @@ export type GoalFeedProps = {
     task: number;
     goal: number;
   };
+  emojis: Array<FeedEmojis>;
 };
 
 export type GoalFeedResponse = {

--- a/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
+++ b/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
@@ -18,6 +18,7 @@ export type GoalProps = {
   tag: string;
   createdAt: string;
 };
+
 export type CountProps = {
   reaction: number;
   comment: number;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 피드 페이지 API 연결
  - 변경된 /goal/explore 적용
  - 이모지 API 추가

## 🎉 어떻게 해결했나요?
- 이모지 API에서 요청 성공시 invalidateQueries를 이용하여 데이터를 갱신하도록 구현

### 📚 Attachment (Option)
음.. 피드 이모지 관련 API 아직도 고민이긴 함...

  - 현재 피드 페이지에서 이모지 추가 / 삭제시 React-Query의 `invalidateQueries`를 사용하여 현재까지 캐싱된 피드 데이터를 모두 다시 불러옴
    - 예) 무한 스크롤 페이지 단위가 10개이고, 30번째 목표까지 화면에서 본 이후, 이모지 추가를 하면 30개에 대한 데이터를 새로 요청
  - 이를 개선하기 위해 처음 생각했던 것이 콜백함수를 통해 업데이트할 목표피드를 찾아 리액션 부분을 업데이트하는 것.
    - 아직 오류가 있어 완벽히 구현하진 못하였지만 낙관적 업데이트를 통해 구현 가능할 것 같음. 하지만 이 또한 목표를 찾는 로직과 객체 복사로 인한 연산에 대한 오버헤드가 발생
  - 또 다른 방법은 서버로부터 피드 데이터를 응답 받은 후, 각 피드에 대한 카드 컴포넌트에서 이모지 관련 데이터를 요청하여 각각의 서버 상태를 관리
    - 즉, 피드의 무한 스크롤의 페이지 단위가 10개라면, 해당 페이지를 불러올때 10개의 목표에 대한 이모지 데이터를 추가로 요청
    - 화면 렌더링시 많은 요청이 가기는 하지만 피드 이모지 추가 / 삭제에 대한 요청은 간단함

https://github.com/depromeet/amazing3-fe/assets/45158550/aaae91e9-3ba0-4823-b032-4f9a28f8b4ca

- 모바일 환경에서 이모지 선택창의 텍스트가 두줄로 나뉘는 현상이 생김
  - 선택창의 너비를 넓히자니 화면에서 짤려 left 속성을 살짝 넣어줌..
  - 좀 찝찝하긴 한데 좋은 방법 있다면 의견 달아주셈!