### PR TITLE
fix: 바텀시트에 하단탭바가 올라가는 이슈 해결

### DIFF
--- a/src/components/atoms/bottomSheet/style.css
+++ b/src/components/atoms/bottomSheet/style.css
@@ -8,6 +8,10 @@
   --rsbs-mr: auto;
 }
 
+[data-rsbs-overlay] {
+  z-index: 99;
+}
+
 [data-rsbs-header] {
   text-align: left;
   padding-bottom: 0;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 바텀시트 위로도 하단탭바가 올라가서 버튼이 가려지는 문제 있었어유


## 🎉 어떻게 해결했나요?

| AS-IS | TO-BE |
|:--:|:--:|
| <img src="https://github.com/depromeet/amazing3-fe/assets/112946860/e9c9ac1a-da30-4bfc-90ba-b89f35a119af" width="400" /> | <img src="https://github.com/depromeet/amazing3-fe/assets/112946860/a66b190f-c015-4311-b731-7c203c32a9d3" width="400" /> |

### 📚 Attachment (Option)
- N/A

