### PR TITLE
feat: 응원한 사람 조회 api 응답 값 수정 반영 / 응원하기 성공 시에도 에러 토스트가 뜨는 버그 수정

### DIFF
--- a/src/features/cheering/Cheerer.tsx
+++ b/src/features/cheering/Cheerer.tsx
@@ -15,7 +15,7 @@ interface CheererProps {
 }
 
 export const Cheerer = ({ userId, userName, userNickName, userImageUrl, cheeringAt }: CheererProps) => {
-  const isDeletedUser = userId === 0;
+  const isDeletedUser = userId === -1;
 
   return (
     <div className="flex items-center justify-between py-5xs">

--- a/src/features/cheering/Cheerer.tsx
+++ b/src/features/cheering/Cheerer.tsx
@@ -15,7 +15,7 @@ interface CheererProps {
 }
 
 export const Cheerer = ({ userId, userName, userNickName, userImageUrl, cheeringAt }: CheererProps) => {
-  const isDeletedUser = userId === -1;
+  const isDeletedUser = userId === 0;
 
   return (
     <div className="flex items-center justify-between py-5xs">

--- a/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
@@ -30,18 +30,16 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
   const CHEER_ANIMATION_INTERVAL = 5400;
 
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout | undefined;
-    if (isSuccess) {
-      setIsCheeringSuccess(true);
-      timeoutId = setTimeout(() => {
-        setIsCheeringSuccess(false);
-      }, CHEER_ANIMATION_INTERVAL);
-    }
+    if (!isSuccess) return;
+
+    setIsCheeringSuccess(true);
+
+    const timeoutId = setTimeout(() => {
+      setIsCheeringSuccess(false);
+    }, CHEER_ANIMATION_INTERVAL);
 
     return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
+      clearTimeout(timeoutId);
     };
   }, [isSuccess]);
 
@@ -54,7 +52,6 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
       open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
       return;
     }
-
     if (!isCheeringSuccess) toast.warning('1분 뒤에 응원할 수 있어요.');
 
     throttleCheer();

--- a/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
@@ -22,20 +22,19 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
   const { open } = useOverlay();
   const toast = useToast();
 
-  const [isCheeringSuccess, setIsCheeringSuccess] = useState(false);
+  const [lastCheerTime, setLastCheerTime] = useState(0);
 
   // TODO: Lottie atom을 수정해서 로티 이미지를 플레이하는 방식으로 변경
   const { mutate: cheer, isSuccess } = useCreateCheering(username);
 
   const CHEER_ANIMATION_INTERVAL = 5400;
+  const CHEER_LIMIT_INTERVAL = 6000;
 
   useEffect(() => {
     if (!isSuccess) return;
 
-    setIsCheeringSuccess(true);
-
     const timeoutId = setTimeout(() => {
-      setIsCheeringSuccess(false);
+      setLastCheerTime(0);
     }, CHEER_ANIMATION_INTERVAL);
 
     return () => {
@@ -52,14 +51,20 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
       open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
       return;
     }
-    if (!isCheeringSuccess) toast.warning('1분 뒤에 응원할 수 있어요.');
 
+    const now = Date.now();
+    if (now - lastCheerTime < CHEER_LIMIT_INTERVAL && lastCheerTime !== 0) {
+      toast.warning('1분 뒤에 응원할 수 있어요.');
+      return;
+    }
+
+    setLastCheerTime(now);
     throttleCheer();
   };
 
   return (
     <>
-      {isCheeringSuccess && <CheeringClickedLottie />}
+      {isSuccess && <CheeringClickedLottie />}
       <div className="flex gap-5xs  px-xs pt-5xs mt-[18px] w-full z-[1]">
         <CheeringButton onClick={handleClickCheeringButton} />
         <Link href={{ pathname: myHomePath }} className="w-full">

--- a/src/hooks/reactQuery/cheering/useGetCheerer.ts
+++ b/src/hooks/reactQuery/cheering/useGetCheerer.ts
@@ -2,17 +2,19 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 import { useGetMemberData } from '@/hooks/reactQuery/auth/useGetMemberData';
-import { createQueryString } from '@/utils/queryString';
 
 export type CheererResponse = {
   contents: {
+    cheererId: number;
     userId: number;
     userName: string;
     userNickName: string;
     userImageUrl: string;
     cheeringAt: string;
+    cursorId: number;
   }[];
-  isLastPage: boolean;
+  isLast: boolean;
+  nextCursor: number;
   total: number;
 };
 
@@ -24,14 +26,12 @@ export const useGetCheerer = () => {
   return useInfiniteQuery<CheererResponse>({
     queryKey: ['cheerer', my?.lifeMap.lifeMapId],
     queryFn: ({ pageParam }) => {
-      const queryString = createQueryString({
-        pageSize: PAGE_SIZE,
-        lastCursorAt: pageParam,
+      return api.get<CheererResponse>(`/cheering/squad/${my?.lifeMap.lifeMapId}`, {
+        params: { cursor: pageParam, size: PAGE_SIZE },
       });
-      return api.get<CheererResponse>(`/cheering/squad/${my?.lifeMap.lifeMapId}?${queryString}`);
     },
     initialPageParam: null,
-    getNextPageParam: ({ isLastPage, contents }) => (isLastPage ? null : contents[contents.length - 1].cheeringAt),
+    getNextPageParam: ({ isLast, nextCursor }) => (isLast ? null : nextCursor),
     enabled: my?.lifeMap.lifeMapId !== undefined,
   });
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
-  응원한 사람 조회 api 응답 값 수정 반영
- 응원하기 성공 시에도 에러 토스트가 뜨는 버그 수정

## 🎉 어떻게 해결했나요?
### 1. api 응답 값 수정
#### AS-IS
- `cursor`: 페이지 내 마지막 응원한 사람의 cheeringAt

#### TO-BE
- `cursor`: 서버에서 보낸 `nextCursor` 값 사용

---

### 2. 응원하기 성공 시에도 에러 토스트가 뜨는 버그 수정

https://github.com/depromeet/amazing3-fe/assets/80238096/29742fb6-d9f7-4611-ba6d-72fdf969ac59

- 이거 더 좋은 방식 아는 사람 있으면 .. 나도 알려줘 ..

### 📚 Attachment (Option)
- 

