### PR TITLE
chore: ReactionUserTotalCount 컴포넌트 디자인 반영

### DIFF
--- a/src/features/goal/components/detail/emoji/ReactionUserTotalCount.tsx
+++ b/src/features/goal/components/detail/emoji/ReactionUserTotalCount.tsx
@@ -22,11 +22,11 @@ export const ReactionUserTotalCount = ({ username, count }: ReactionUserTotalCou
 
   const ShowText = () => {
     if (countExceptOne === 0) {
-      return `${formatOverLength(username, 2)}님이 목표에 반응했어요.`;
+      return `${formatOverLength(username)}님이 목표에 반응했어요.`;
     }
     return (
       <>
-        {formatOverLength(username, 2)}님 외&nbsp;
+        {formatOverLength(username)}님 외&nbsp;
         <span className="text-blue-50">{formatOver999(countExceptOne)}</span>명이 반응했어요.
       </>
     );
@@ -38,14 +38,18 @@ export const ReactionUserTotalCount = ({ username, count }: ReactionUserTotalCou
 
   return (
     <button
-      className="relative w-full flex justify-center items-center rounded-[12px] bg-gray-10 gap-5xs py-5xs"
+      className="w-full flex justify-center items-center rounded-[12px] bg-gray-10 gap-5xs py-5xs"
       onClick={handleOpenMembersBottomSheet}
     >
-      <Image src={ReactionMembersImage} width={54} height={36} alt="reaction_members_image" />
-      <Typography type="body3">
-        <ShowText />
-      </Typography>
-      <ArrowIcon width="24" height="24" className="absolute right-[10px] rotate-180" />
+      <div className="relative w-full h-[36px] flex items-center">
+        <div className="absolute left-[19px] flex gap-2xs items-center">
+          <Image src={ReactionMembersImage} width={54} height={36} alt="reaction_members_image" />
+          <Typography type="body3">
+            <ShowText />
+          </Typography>
+        </div>
+        <ArrowIcon width="24" height="24" className="absolute right-[10px] rotate-180" />
+      </div>
     </button>
   );
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [XX 외 몇 명이 반응했어요 UI에서 닉네임 2글자 → 3글자까지 보이도록](https://www.notion.so/depromeet/XX-UI-2-3-4913a6ecdb614696a1814f14a787ab95?pvs=4)
- [내 이모지 누른사람 박스에서 좌측 프로필 위치 고정, 프로필과 텍스트 마진 유지](https://www.notion.so/depromeet/136e48c479c848478b1a09b6c16507d9?pvs=4)

## 🎉 어떻게 해결했나요?

| AS-IS | TO-BE |
|:--:|:--:|
| ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/e1b66abe-eacf-4c94-bdd7-997044d0b66c) | ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/8e85be9b-c0a5-47b9-bdb8-ed0b9f4b5f4a) |


### 📚 Attachment (Option)
- N/A

