### PR TITLE
bug: 타임라인 댓글 작성 / 삭제 시, 댓글 개수가 반영되지 않는 이슈 수정

### DIFF
--- a/src/hooks/reactQuery/comment/useCreateComment.ts
+++ b/src/hooks/reactQuery/comment/useCreateComment.ts
@@ -1,7 +1,12 @@
+import { usePathname } from 'next/navigation';
+import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 import { useToast } from '@/hooks';
+
+import type { TimelineResponse } from '../goal/useGetTimeline';
+import { useOptimisticUpdate } from '../useOptimisticUpdate';
 
 type CommentRequest = {
   goalId: number;
@@ -9,14 +14,45 @@ type CommentRequest = {
 };
 
 export const useCreateComment = () => {
+  const pathname = usePathname();
+  const [, , username] = pathname.split('/');
   const toast = useToast();
   const queryClient = useQueryClient();
+  const { queryClient: optimisticQueryClient, optimisticUpdater } = useOptimisticUpdate();
+
+  const targetQueryKey = ['timeline', username];
 
   return useMutation({
     mutationFn: ({ goalId, content }: CommentRequest) => api.post(`/goal/${goalId}/comment`, { content }),
-    onSuccess: (_, variable) => queryClient.invalidateQueries({ queryKey: ['comment', variable.goalId] }),
-    onError: () => {
+    onMutate: async ({ goalId }) => {
+      const updater = (old: InfiniteData<TimelineResponse>) => {
+        const newPages = old.pages.map((page) => ({
+          ...page,
+          contents: page.contents.map((content) =>
+            content.goal.goalId === goalId
+              ? {
+                  ...content,
+                  counts: {
+                    ...content.counts,
+                    comment: content.counts.comment + 1,
+                  },
+                }
+              : content,
+          ),
+        }));
+
+        return { ...old, pages: newPages };
+      };
+
+      return await optimisticUpdater({ queryKey: targetQueryKey, updater });
+    },
+    onSuccess: (_, variable) => {
+      queryClient.invalidateQueries({ queryKey: ['comment', variable.goalId] });
+    },
+    onError: (_, __, context) => {
       toast.warning('잠시후 다시 시도해주세요.');
+
+      optimisticQueryClient.setQueryData(targetQueryKey, context?.previous);
     },
   });
 };

--- a/src/hooks/reactQuery/comment/useDeleteComment.ts
+++ b/src/hooks/reactQuery/comment/useDeleteComment.ts
@@ -1,8 +1,11 @@
+import { usePathname } from 'next/navigation';
+import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 import { useToast } from '@/hooks/useToast';
 
+import type { TimelineResponse } from '../goal/useGetTimeline';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
 
 import type { CommentResponse } from './useGetComment';
@@ -13,6 +16,8 @@ type CommentDeleteRequest = {
 };
 
 export const useDeleteComment = () => {
+  const pathname = usePathname();
+  const [, , username] = pathname.split('/');
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
   const toast = useToast();
 
@@ -28,8 +33,27 @@ export const useDeleteComment = () => {
       const context = await optimisticUpdater({ queryKey: targetQueryKey, updater });
       return context;
     },
-    onSuccess: () => {
+    onSuccess: (_, { goalId }) => {
       toast.success('댓글을 삭제했어요.');
+
+      queryClient.setQueryData(['timeline', username], (old: InfiniteData<TimelineResponse>) => {
+        const newPages = old?.pages.map((page) => ({
+          ...page,
+          contents: page.contents.map((content) =>
+            content.goal.goalId === goalId
+              ? {
+                  ...content,
+                  counts: {
+                    ...content.counts,
+                    comment: content.counts.comment - 1,
+                  },
+                }
+              : content,
+          ),
+        }));
+
+        return { ...old, pages: newPages };
+      });
     },
     onError: (_, variable, context) => {
       toast.warning('댓글 삭제에 실패했어요.');


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [타임라인 댓글 작성 / 삭제 시, 댓글 개수가 반영되지 않는 이슈 수정](https://www.notion.so/depromeet/e4ba1950fb7142daaf388dcf2bbbae83?p=fe7e438732b143c384f1695803591091&pm=s)

## 🎉 어떻게 해결했나요?

- 댓글 작성 시, 낙관적 업데이트 적용
- 댓글 삭제 시, 캐시 값 수정
   - 댓글 삭제 시, 다른 쿼리에 낙관적 업데이트 적용하고 있어서 setQueryData로 했는데 댓글 작성 시에도 setQueryData로 통일할까 고민 중..🫨

https://github.com/depromeet/amazing3-fe/assets/80238096/67eab62b-e5ee-41fa-b4fa-47ac53c866c0



### 📚 Attachment (Option)
- 현재 타임라인 api 수정 중이라 pull 받아서 테스트하면 댓글 개수가 정상적으로 안보일 수 있음

