### PR TITLE
fix: 이미 존재하는 이모지를 + 버튼을 이용하여 새로 추가할 때 내가 반응한 이모지로 표기되지 않는 현상 수정

### DIFF
--- a/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
+++ b/src/features/feed/feedCard/reactionGroup/ReactedEmojiButton.tsx
@@ -1,4 +1,4 @@
-import { type ButtonHTMLAttributes, useState } from 'react';
+import { type ButtonHTMLAttributes } from 'react';
 
 import { Emoji, Typography } from '@/components';
 import { useCreateEmojiForFeed } from '@/hooks/reactQuery/emoji/useCreateEmojiForFeed';
@@ -25,13 +25,10 @@ export const ReactedEmojiButton = ({
   onCloseEmojis,
   ...props
 }: ReactedEmojiButtonProps) => {
-  const [isClicked, setIsClicked] = useState(isMyReaction);
   const { mutate: createReactEmoji } = useCreateEmojiForFeed();
   const { mutate: deleteReactedEmoji } = useDeleteReactedEmojiForFeed();
 
   const handleClickButton = () => {
-    setIsClicked((prev) => !prev);
-
     isMyReaction ? deleteReactedEmoji({ goalId, emojiId }) : createReactEmoji({ goalId, emojiId });
 
     onCloseEmojis();
@@ -42,13 +39,13 @@ export const ReactedEmojiButton = ({
   return (
     <button
       className={`py-6xs px-5xs flex gap-6xs items-center rounded-full border box-border ${
-        isClicked ? 'bg-blue-10 border-blue-50' : 'bg-gray-10 border-white'
+        isMyReaction ? 'bg-blue-10 border-blue-50' : 'bg-gray-10 border-white'
       }`}
       onClick={handleClickButton}
       {...props}
     >
       <Emoji url={url} size={24} name={name} />
-      <Typography type="caption1" className={`${isClicked ? 'text-blue-50' : 'text-gray-40'}`}>
+      <Typography type="caption1" className={`${isMyReaction ? 'text-blue-50' : 'text-gray-40'}`}>
         {formatOver999(count)}
       </Typography>
     </button>

--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 
-import type { GoalFeedResponse } from '../goal/useGetGoalFeeds';
+import type { EmojisProps, GoalFeedResponse } from '../goal/useGetGoalFeeds';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
 
 import type { Emoji, EmojisResponse } from './useGetAllEmoji';
@@ -13,10 +13,6 @@ type EmojiRequestParams = {
   emojiId: number;
 };
 
-interface GoalFeedInfinityResponse extends InfiniteData<GoalFeedResponse, unknown> {}
-
-const NOT_FOUNDED_INDEX = -1;
-
 export const useCreateEmojiForFeed = () => {
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
   const targetQueryKey = ['goalFeeds'];
@@ -24,43 +20,35 @@ export const useCreateEmojiForFeed = () => {
   return useMutation({
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.post(`/goal/${goalId}/emoji/${emojiId}`),
     onMutate: async ({ goalId, emojiId }) => {
-      const updater = (old: GoalFeedInfinityResponse): GoalFeedInfinityResponse => {
-        const newData = JSON.parse(JSON.stringify(old)) as GoalFeedInfinityResponse;
+      const updater = (old: InfiniteData<GoalFeedResponse>) => {
         const reactEmojiData = queryClient
           .getQueryData<EmojisResponse>(['all-emoji'])
           ?.find((emoji) => emoji.id === emojiId) as Emoji;
 
-        let currentPage,
-          pageIndex = NOT_FOUNDED_INDEX,
-          goalIndex = NOT_FOUNDED_INDEX;
-
-        while (pageIndex < newData.pages.length && goalIndex < 0) {
-          pageIndex++;
-          currentPage = newData.pages[pageIndex];
-          goalIndex = currentPage.goals.findIndex(({ goal }) => goal.id === goalId);
-        }
-
-        if (!currentPage) return old;
-
-        const targetGoal = currentPage.goals[goalIndex];
-        const targetEmojis = targetGoal.emojis;
-        const existedEmojiIndex = targetEmojis.findIndex(({ id }) => id === emojiId);
-
-        let newEmoji = null;
-
-        if (existedEmojiIndex === NOT_FOUNDED_INDEX) {
-          newEmoji = { ...reactEmojiData, reactCount: 1, isMyReaction: true };
-        } else {
-          const targetEmoji = targetEmojis[existedEmojiIndex];
-          newEmoji = { ...targetEmoji, reactCount: targetEmoji.reactCount + 1 };
-          targetEmojis.splice(existedEmojiIndex, 1, newEmoji);
-        }
-
-        const newEmojis = existedEmojiIndex >= 0 ? targetEmojis : [...targetEmojis, newEmoji];
-        targetGoal.emojis = newEmojis;
-        targetGoal.count.reaction++;
-
-        return newData;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            goals: page.goals.map((goal) =>
+              goal.goal.id === goalId
+                ? {
+                    ...goal,
+                    emojis: goal.emojis.find(({ id }) => id === emojiId)
+                      ? goal.emojis.map((emoji) =>
+                          emoji.id === emojiId
+                            ? { ...emoji, reactCount: emoji.reactCount + 1, isMyReaction: true }
+                            : emoji,
+                        )
+                      : [
+                          ...goal.emojis,
+                          { ...reactEmojiData, id: emojiId, reactCount: 1, isMyReaction: true } as EmojisProps,
+                        ],
+                    count: { ...goal.count, reaction: goal.count.reaction + 1 },
+                  }
+                : goal,
+            ),
+          })),
+        };
       };
 
       const context = await optimisticUpdater({

--- a/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
@@ -30,7 +30,7 @@ export const useDeleteReactedEmojiForFeed = () => {
                     emojis: goal.emojis
                       .map((emoji) =>
                         emoji.id === emojiId
-                          ? { ...emoji, reactCount: emoji.reactCount - 1, isMyReaction: true }
+                          ? { ...emoji, reactCount: emoji.reactCount - 1, isMyReaction: false }
                           : emoji,
                       )
                       .filter(({ reactCount }) => reactCount > 0),
@@ -49,7 +49,6 @@ export const useDeleteReactedEmojiForFeed = () => {
       return context;
     },
     onSuccess: (_, { goalId }) => {
-      // queryClient.invalidateQueries({ queryKey: ['goalFeeds'] });
       queryClient.invalidateQueries({ queryKey: ['emoji', goalId] });
     },
     onError: (_, __, context) => {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 피드에 이미 존재하는 이모지를 + 버튼을 이용해 추가할 경우, 내가 반응한 이모지로 표기되지 않는 현상

## 🎉 어떻게 해결했나요?
- 불필요한 상태가 존재하여 삭제하고, 캐싱 데이터를 바로 상태로 사용하였습니다.

### 📚 Attachment (Option)
- API 요청 후, 캐싱 데이터 수정 로직을 리팩토링했습니다

| AS-IS | TO-BE |
|:--:|:--:|
| <video src="https://github.com/depromeet/amazing3-fe/assets/45158550/d5ad490e-a920-49ef-b374-166323e4ab97" /> | <video src="https://github.com/depromeet/amazing3-fe/assets/45158550/1352e943-f62e-4b43-a105-96263a1a72d5" /> |

