### PR TITLE
refactor: 생년월일 입력 - 변경된 디자인 적용 및 리팩터링

### DIFF
--- a/src/constants/date.ts
+++ b/src/constants/date.ts
@@ -1,0 +1,1 @@
+export const DATE_SEPARATOR = '.';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export { blueDataURL } from './blurDataURL';
+export * from './date';
 export * from './input';
 export { META } from './metadata';
 export * from './ogImage.size';

--- a/src/features/goal/components/new/DateForm.tsx
+++ b/src/features/goal/components/new/DateForm.tsx
@@ -4,10 +4,10 @@ import { useController, useFormContext } from 'react-hook-form';
 import Link from 'next/link';
 
 import { Button, Span, Typography } from '@/components';
-import { MAX_DATE_LENGTH_UNTIL_MONTH } from '@/constants';
 import type { GoalFormValues } from '@/features/goal/types';
 
 import { NEW_GOAL_FORM_ORDERS } from '../../constants';
+import { isValidDateFormat } from '../../utils/date';
 
 import { DateInput } from './DateInput';
 import FormHeader from './FormHeader';
@@ -29,12 +29,12 @@ export const DateForm = () => {
       }
       body={
         <div {...register('date')} className="pt-sm">
-          <DateInput maxLength={MAX_DATE_LENGTH_UNTIL_MONTH} onChange={onChange} />
+          <DateInput onChange={onChange} requireDateType={['YYYY', 'MM']} />
         </div>
       }
       footer={
         <Link href="/goal/new/tag">
-          <Button disabled={value ? value.length !== MAX_DATE_LENGTH_UNTIL_MONTH : true}>다음</Button>
+          <Button disabled={!isValidDateFormat(value, 'YYYY.MM')}>다음</Button>
         </Link>
       }
     />

--- a/src/features/goal/utils/date.ts
+++ b/src/features/goal/utils/date.ts
@@ -1,4 +1,8 @@
-export const formatDate = (splitedDate: string[], separator: string) => {
+import { DATE_SEPARATOR } from '@/constants';
+import type { DateProps } from '@/hooks/useDateInput';
+import { typeToMaxLength } from '@/hooks/useDateInput';
+
+export const formatDate = (splitedDate: string[], separator = DATE_SEPARATOR) => {
   return splitedDate.join(separator);
 };
 
@@ -10,4 +14,17 @@ export const isValidDate = (year: string, month: string, day: string) => {
   const date = new Date(yearNum, monthNum, dayNum);
 
   return date.getFullYear() === yearNum && date.getMonth() === monthNum && date.getDate() === dayNum;
+};
+
+/**
+ *
+ * @param string DATE_SEPARATOR를 기준으로 split했을 때, 모든 아이템이 number여야만, 길이를 만족해야만 true를 반환합니다.
+ * @param format ex. 'YYYY.MM.DD'
+ */
+export const isValidDateFormat = (formattedDate = '', format: string) => {
+  const splittedFormat = format.split(DATE_SEPARATOR) as DateProps[];
+
+  return formattedDate
+    .split(DATE_SEPARATOR)
+    .every((date, index) => !isNaN(+date) && date.length === typeToMaxLength[splittedFormat[index]]);
 };

--- a/src/features/goal/utils/date.ts
+++ b/src/features/goal/utils/date.ts
@@ -21,10 +21,13 @@ export const isValidDate = (year: string, month: string, day: string) => {
  * @param string DATE_SEPARATOR를 기준으로 split했을 때, 모든 아이템이 number여야만, 길이를 만족해야만 true를 반환합니다.
  * @param format ex. 'YYYY.MM.DD'
  */
-export const isValidDateFormat = (formattedDate = '', format: string) => {
+export const isValidDateFormat = (formattedDate = '', format = 'YYYY.MM.DD') => {
   const splittedFormat = format.split(DATE_SEPARATOR) as DateProps[];
 
-  return formattedDate
-    .split(DATE_SEPARATOR)
-    .every((date, index) => !isNaN(+date) && date.length === typeToMaxLength[splittedFormat[index]]);
+  return (
+    formattedDate
+      .split(DATE_SEPARATOR)
+      .every((date, index) => !isNaN(+date) && date.length === typeToMaxLength[splittedFormat[index]]) &&
+    formattedDate.split(DATE_SEPARATOR).length === splittedFormat.length
+  );
 };

--- a/src/features/member/components/new/BirthInputForm.tsx
+++ b/src/features/member/components/new/BirthInputForm.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import BirthIcon from '@/assets/icons/birth-icon.svg';
 import { Button } from '@/components';
 import { DateInput } from '@/features/goal/components/new/DateInput';
+import { isValidDateFormat } from '@/features/goal/utils/date';
 
 import type { NewMemberFormValues } from '../../types';
 
@@ -36,7 +37,9 @@ export const BirthInputForm = () => {
           <div {...register('birth')}>
             <DateInput onChange={onChange} />
           </div>
-          <Button type="submit">{value?.length ? '완료' : '건너뛰기'}</Button>
+          <Button type="submit" disabled={value?.length ? !isValidDateFormat(value) : false}>
+            {value?.length ? '완료' : '건너뛰기'}
+          </Button>
         </div>
       </div>
     </FormLayout>

--- a/src/features/my/components/update/UpdateForm.tsx
+++ b/src/features/my/components/update/UpdateForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Button } from '@/components';
-import { MAX_DATE_LENGTH_UNTIL_DAY, MAX_NICKNAME_LENGTH, MAX_USERNAME_LENGTH } from '@/constants';
+import { MAX_NICKNAME_LENGTH, MAX_USERNAME_LENGTH } from '@/constants';
 import { DateInput } from '@/features/goal/components/new/DateInput';
 import { TextInput } from '@/features/goal/components/new/TextInput';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
@@ -25,6 +25,8 @@ export const UpdateForm = () => {
   const { field: birthField } = useController({ name: 'birth', control });
   const { field: usernameField } = useController({ name: 'username', control });
   const isValidBirth = useValidBirth(birthField.value);
+
+  const [defaultYYYY, defaultMM, defaultDD] = (memberData?.birth ?? '').split('-');
 
   const [isDisabledSubmit, setIsDisabledSubmit] = useState(true);
 
@@ -85,8 +87,7 @@ export const UpdateForm = () => {
               <div {...register('birth')}>
                 <DateInput
                   labelName="생년월일"
-                  intitalValue={memberData.birth?.replace(/\-/g, '.')}
-                  maxLength={MAX_DATE_LENGTH_UNTIL_DAY}
+                  initialValue={{ YYYY: defaultYYYY, MM: defaultMM, DD: defaultDD }}
                   onChange={birthField.onChange}
                 />
               </div>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAuth } from './useAuth';
+export { useDateInput } from './useDateInput';
 export { useDebounceCall } from './useDebounceCall';
 export { useDownloadImage } from './useDownloadImage';
 export { useFocusInput } from './useFocusInput';

--- a/src/hooks/useDateInput.ts
+++ b/src/hooks/useDateInput.ts
@@ -1,0 +1,55 @@
+import type { ChangeEvent, FocusEvent } from 'react';
+import { useRef, useState } from 'react';
+
+export type DateProps = 'YYYY' | 'MM' | 'DD';
+
+export type DateValueProps = Record<DateProps, string>;
+
+interface UseDateInputProps {
+  initialValue: DateValueProps;
+}
+
+export const typeToMaxLength: Record<DateProps, number> = {
+  YYYY: 4,
+  MM: 2,
+  DD: 2,
+} as const;
+
+export const useDateInput = ({ initialValue }: UseDateInputProps) => {
+  const [dateValues, setDateValues] = useState<DateValueProps>(initialValue);
+
+  const yearInputRef = useRef<HTMLInputElement>(null);
+  const monthInputRef = useRef<HTMLInputElement>(null);
+  const dayInputRef = useRef<HTMLInputElement>(null);
+
+  const inputRefs = {
+    YYYY: yearInputRef,
+    MM: monthInputRef,
+    DD: dayInputRef,
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>, type: DateProps) => {
+    let inputValue = event.target.value;
+
+    if (type === 'YYYY' && inputValue.length === typeToMaxLength[type]) {
+      monthInputRef.current?.focus();
+    }
+
+    if (type === 'MM') {
+      inputValue = +inputValue > 12 ? '12' : inputValue;
+      if (inputValue.length === typeToMaxLength.MM) dayInputRef.current?.focus();
+    }
+
+    setDateValues((prev) => ({ ...prev, [type]: inputValue }));
+  };
+
+  const handleInputBlur = (event: FocusEvent<HTMLInputElement>, type: DateProps) => {
+    const inputValue = event.target.value;
+
+    if ((type === 'MM' || type === 'DD') && inputValue.length === 1) {
+      setDateValues((prev) => ({ ...prev, [type]: `0${inputValue}` }));
+    }
+  };
+
+  return { dateValues, handleInputChange, handleInputBlur, inputRefs };
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,7 @@
 import { DATE_SEPARATOR, HOURS_PER_DAY, MINUTES_PER_HOUR, SECONDS_PER_MINUTE } from '@/constants';
 
 export const formatDate = (splitedDate: string[], separator = DATE_SEPARATOR) => {
-  return splitedDate.join(separator);
+  return splitedDate.filter((date) => date !== '').join(separator);
 };
 
 export const isValidDate = (year: string, month: string, day?: string) => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,6 @@
-import { HOURS_PER_DAY, MINUTES_PER_HOUR, SECONDS_PER_MINUTE } from '@/constants';
+import { DATE_SEPARATOR, HOURS_PER_DAY, MINUTES_PER_HOUR, SECONDS_PER_MINUTE } from '@/constants';
 
-export const formatDate = (splitedDate: string[], separator: string) => {
+export const formatDate = (splitedDate: string[], separator = DATE_SEPARATOR) => {
   return splitedDate.join(separator);
 };
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 변경된 생년월일 입력 부분 디자인 반영 ([figma](https://www.figma.com/file/hREAodauJnxgE6SBuF0ZYR/UI%2FDesgin-system?node-id=2528%3A32255&mode=dev))

## 🎉 어떻게 해결했나요?

### 1. member/new/birth : 디자인 반영 및 유효성 검증 추가
- 사용자가 입력을 시작하면, 유효성 검증할 수 있도록

![GIFMaker_me (1)](https://github.com/depromeet/amazing3-fe/assets/112946860/2b8d084b-ad4c-44d4-99b5-0c724ae81d26)

### 2. 목표추가/date : 디자인 반영 및 유효성 검증 부분 리팩터링
![GIFMaker_me (2)](https://github.com/depromeet/amazing3-fe/assets/112946860/c0dcef5c-0483-484d-8344-d4745d2633b3)

### 3. my/update : 디자인 반영

![GIFMaker_me (3)](https://github.com/depromeet/amazing3-fe/assets/112946860/6beeed39-b414-49fc-be62-0b3ee4eeec60)

### 📚 Attachment (Option)

- https://github.com/depromeet/amazing3-fe/pull/233 👈 요거 망가져서 똑같이 다시 올려유


