### PR TITLE
bug: 정보수정 페이지에서 birth 없이 수정 가능하도록

### DIFF
--- a/src/features/goal/components/new/DateInput.tsx
+++ b/src/features/goal/components/new/DateInput.tsx
@@ -39,7 +39,7 @@ export const DateInput = ({
             placeholder={type}
             className="text-center"
             maxLength={typeToMaxLength[type]}
-            value={dateValues[type]}
+            value={dateValues[type] || ''} // uncontrolled warning 때문에 defaultValue 필요
             onChange={(e) => handleInputChange(e, type)}
             onBlur={(e) => handleInputBlur(e, type)}
           />

--- a/src/features/goal/utils/date.ts
+++ b/src/features/goal/utils/date.ts
@@ -2,10 +2,6 @@ import { DATE_SEPARATOR } from '@/constants';
 import type { DateProps } from '@/hooks/useDateInput';
 import { typeToMaxLength } from '@/hooks/useDateInput';
 
-export const formatDate = (splitedDate: string[], separator = DATE_SEPARATOR) => {
-  return splitedDate.join(separator);
-};
-
 export const isValidDate = (year: string, month: string, day: string) => {
   const yearNum = +year;
   const monthNum = +month - 1;

--- a/src/features/my/components/update/UpdateForm.tsx
+++ b/src/features/my/components/update/UpdateForm.tsx
@@ -7,8 +7,8 @@ import { Button } from '@/components';
 import { MAX_NICKNAME_LENGTH, MAX_USERNAME_LENGTH } from '@/constants';
 import { DateInput } from '@/features/goal/components/new/DateInput';
 import { TextInput } from '@/features/goal/components/new/TextInput';
+import { isValidDateFormat } from '@/features/goal/utils/date';
 import { useGetMemberData } from '@/hooks/reactQuery/auth';
-import { useValidBirth } from '@/hooks/useValidBirth';
 
 import type { UpdateMemberDataFormValues } from '../../types';
 
@@ -24,7 +24,7 @@ export const UpdateForm = () => {
   const { field: nicknameField } = useController({ name: 'nickname', control });
   const { field: birthField } = useController({ name: 'birth', control });
   const { field: usernameField } = useController({ name: 'username', control });
-  const isValidBirth = useValidBirth(birthField.value);
+  const isValidBirth = birthField.value?.length ? isValidDateFormat(birthField.value) : true;
 
   const [defaultYYYY, defaultMM, defaultDD] = (memberData?.birth ?? '').split('-');
 
@@ -44,8 +44,7 @@ export const UpdateForm = () => {
       !memberData ||
       imageField.value === undefined ||
       nicknameField.value === undefined ||
-      usernameField.value === undefined ||
-      birthField.value === undefined
+      usernameField.value === undefined
     )
       return;
 
@@ -53,13 +52,10 @@ export const UpdateForm = () => {
       memberData.image === imageField.value &&
       memberData.nickname === nicknameField.value &&
       memberData.username === usernameField.value &&
-      memberData.birth === birthField.value;
+      (memberData.birth || '') === birthField.value;
 
     const isNotFilled =
-      imageField.value.length === 0 ||
-      nicknameField.value.length === 0 ||
-      usernameField.value.length === 0 ||
-      birthField.value?.length !== 10;
+      imageField.value.length === 0 || nicknameField.value.length === 0 || usernameField.value.length === 0;
 
     setIsDisabledSubmit(isNotFilled || isNotModified || !isValidBirth);
   }, [memberData, imageField, nicknameField, birthField, usernameField, isValidBirth]);

--- a/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
+++ b/src/features/my/contexts/UpdateMemberDataFormProvider.tsx
@@ -25,7 +25,7 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
 
   const submit = (formData: UpdateMemberDataFormValues) => {
     const { nickname, username, birth } = formData;
-    if (!nickname || !username || !birth) return;
+    if (!nickname || !username) return;
 
     // TODO: react-hook-form을 사용하는 input field는 별도로 component로 분리해서 에러 상태에 대한 처리를 할 수 있도록 수정
     if (memberData?.username !== username && username.toUpperCase().startsWith('BANDIBOODI-')) {
@@ -41,9 +41,9 @@ const UpdateMemberDataFormProvider = ({ children }: PropsWithChildren) => {
 
     // Convert birth from "YYYY.MM.DD" to "YYYY-MM-DD"
     // TODO: 서버에서 YYYY.MM.DD 형식을 지원하면 이 부분 삭제
-    const convertedBirth = birth.replace(/\./g, '-');
+    const convertedBirth = birth?.replace(/\./g, '-');
 
-    mutate({ ...formData, birth: convertedBirth });
+    mutate({ ...formData, ...(convertedBirth && { birth: convertedBirth }) });
   };
 
   return (

--- a/src/hooks/reactQuery/auth/useUpdateMemberData.ts
+++ b/src/hooks/reactQuery/auth/useUpdateMemberData.ts
@@ -5,7 +5,7 @@ import { useToast } from '@/hooks/useToast';
 
 export interface UpdateMemberRequest {
   nickname: string;
-  birth: string;
+  birth?: string;
   username: string;
   image: string;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,7 @@
 import { DATE_SEPARATOR, HOURS_PER_DAY, MINUTES_PER_HOUR, SECONDS_PER_MINUTE } from '@/constants';
 
 export const formatDate = (splitedDate: string[], separator = DATE_SEPARATOR) => {
-  return splitedDate.filter((date) => date !== '').join(separator);
+  return splitedDate.filter((date) => date !== '' && date !== undefined).join(separator);
 };
 
 export const isValidDate = (year: string, month: string, day?: string) => {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [마이페이지에서 내 정보 수정 눌렀을 때 생년월일 비어있는 경우 저장 버튼 활성화가 안 됨](https://www.notion.so/depromeet/6629b243a0584c4aa6bab37ee2d6146a?pvs=4)

## 🎉 어떻게 해결했나요?

추가로, 아래 경우에 요청이 허용됩니다
- birth 제거
- birth가 없는 상태, 다른 필드 수정

🚨 `birth 값 길이 > 0` 이라면 유효성 검사

| AS-IS | TO-BE |
|:--:|:--:|
| <img src="https://github.com/depromeet/amazing3-fe/assets/112946860/0e4b8ea7-3954-4088-a248-55e5657391fe" width="400"  />| <video src="https://github.com/depromeet/amazing3-fe/assets/112946860/5d75fcf8-d1b5-404b-9ac2-5d51873f5434" /> |



### 📚 Attachment (Option)
- N/A

