### PR TITLE
fix: 타임라인 이모지 추가 / 삭제 안되는 이슈 수정

### DIFF
--- a/src/features/feed/FeedBody.tsx
+++ b/src/features/feed/FeedBody.tsx
@@ -28,8 +28,8 @@ export const FeedBody = () => {
         <InfiniteScroller isLastPage={!hasNextPage} onIntersect={() => fetchNextPage()}>
           <div className="mx-xs my-xs flex flex-col gap-md">
             {goalFeedsData?.pages.map(
-              ({ goals }) =>
-                createFeedDataGroupedByUser(goals)?.map((feedData) => {
+              (feedData) =>
+                createFeedDataGroupedByUser(feedData?.goals)?.map((feedData) => {
                   const recentGoalId = feedData[0].goal.id;
                   return <FeedCard key={recentGoalId} feedData={feedData} />;
                 }),

--- a/src/features/home/components/timeline/PrivateTimeline.tsx
+++ b/src/features/home/components/timeline/PrivateTimeline.tsx
@@ -9,7 +9,7 @@ import TimelineCard from './TimelineCard';
 
 export const PrivateTimeline = () => {
   const { data: timeline, fetchNextPage, hasNextPage } = useGetTimeline();
-  const isEmptyGoal = timeline.pages[0].contents.length === 0;
+  const isEmptyGoal = timeline.pages[0].contents?.length === 0;
 
   return (
     <>
@@ -18,17 +18,18 @@ export const PrivateTimeline = () => {
       ) : (
         <InfiniteScroller isLastPage={!hasNextPage} onIntersect={() => fetchNextPage()}>
           <div className="mx-xs my-xs flex flex-col gap-md">
-            {timeline.pages.map(({ contents }) =>
-              contents.map((timeline, index) => {
-                const { goal } = timeline;
-                return (
-                  <TimelineCard
-                    key={goal.goalId}
-                    timeline={timeline}
-                    isSameYear={index > 0 && getYYYY(goal.deadline) === getYYYY(contents[index - 1].goal.deadline)}
-                  />
-                );
-              }),
+            {timeline.pages.map(
+              ({ contents }) =>
+                contents?.map((timeline, index) => {
+                  const { goal } = timeline;
+                  return (
+                    <TimelineCard
+                      key={goal.goalId}
+                      timeline={timeline}
+                      isSameYear={index > 0 && getYYYY(goal.deadline) === getYYYY(contents[index - 1].goal.deadline)}
+                    />
+                  );
+                }),
             )}
           </div>
         </InfiniteScroller>

--- a/src/features/home/hooks/useUpdateFeedEmojiCount.ts
+++ b/src/features/home/hooks/useUpdateFeedEmojiCount.ts
@@ -1,0 +1,39 @@
+import type { InfiniteData } from '@tanstack/react-query';
+
+import type { GoalFeedResponse } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
+
+interface useUpdateFeedEmojiCountProps {
+  isAddingEmoji: boolean;
+}
+
+export const useUpdateFeedEmojiCount = ({ isAddingEmoji }: useUpdateFeedEmojiCountProps) => {
+  const updateFeedEmojiCount = (goalId: number, emojiId: number) => (old: InfiniteData<GoalFeedResponse>) => {
+    if (!old) return { pages: [null], pageParams: [null] };
+
+    const newPages = old?.pages?.map((page) => ({
+      ...page,
+      goals: page?.goals?.map((goal) =>
+        goal.goal.id === goalId
+          ? {
+              ...goal,
+              emojis: goal.emojis
+                ?.map((emoji) =>
+                  emoji.id === emojiId
+                    ? { ...emoji, reactCount: emoji.reactCount + (isAddingEmoji ? 1 : -1), isMyReaction: isAddingEmoji }
+                    : emoji,
+                )
+                ?.filter(({ reactCount }) => reactCount > 0),
+              count: { ...goal.count, reaction: goal.count.reaction + (isAddingEmoji ? 1 : -1) },
+            }
+          : goal,
+      ),
+    }));
+
+    return { ...old, pages: newPages };
+  };
+
+  return {
+    queryKey: ['goalFeeds'],
+    updateFeedEmojiCount,
+  };
+};

--- a/src/features/home/hooks/useUpdateTimelineCommentCount.ts
+++ b/src/features/home/hooks/useUpdateTimelineCommentCount.ts
@@ -16,9 +16,11 @@ export const useUpdateTimelineCommentCount = ({ isAddingComment }: useUpdateTime
   const queryKey = isMyMap ? ['timeline'] : ['publicTimeline', username];
 
   const updateTimelineCommentCount = (goalId: number) => (old: InfiniteData<TimelineResponse>) => {
-    const newPages = old?.pages.map((page) => ({
+    if (!old) return { pages: [null], pageParams: [null] };
+
+    const newPages = old?.pages?.map((page) => ({
       ...page,
-      contents: page.contents.map((content) =>
+      contents: page?.contents?.map((content) =>
         content.goal.goalId === goalId
           ? {
               ...content,

--- a/src/features/home/hooks/useUpdateTimelineEmojiCount.ts
+++ b/src/features/home/hooks/useUpdateTimelineEmojiCount.ts
@@ -16,9 +16,11 @@ export const useUpdateTimelineEmojiCount = ({ isAddingEmoji }: useUpdateTimeline
   const queryKey = isMyMap ? ['timeline'] : ['publicTimeline', username];
 
   const updateTimelineEmojiCount = (goalId: number, emojiId: number) => (old: InfiniteData<TimelineResponse>) => {
-    const newPages = old?.pages.map((page) => ({
+    if (!old) return { pages: [null], pageParams: [null] };
+
+    const newPages = old?.pages?.map((page) => ({
       ...page,
-      contents: page.contents.map((content) =>
+      contents: page?.contents?.map((content) =>
         content.goal.goalId === goalId
           ? {
               ...content,

--- a/src/features/home/hooks/useUpdateTimelineEmojiCount.ts
+++ b/src/features/home/hooks/useUpdateTimelineEmojiCount.ts
@@ -1,0 +1,42 @@
+import { usePathname } from 'next/navigation';
+import type { InfiniteData } from '@tanstack/react-query';
+
+import { useIsMyMap } from '@/hooks';
+import type { TimelineResponse } from '@/hooks/reactQuery/goal/useGetTimeline';
+
+interface useUpdateTimelineEmojiCountProps {
+  isAddingEmoji: boolean;
+}
+
+export const useUpdateTimelineEmojiCount = ({ isAddingEmoji }: useUpdateTimelineEmojiCountProps) => {
+  const pathname = usePathname();
+  const [, , username] = pathname.split('/');
+
+  const { isMyMap } = useIsMyMap();
+  const queryKey = isMyMap ? ['timeline'] : ['publicTimeline', username];
+
+  const updateTimelineEmojiCount = (goalId: number, emojiId: number) => (old: InfiniteData<TimelineResponse>) => {
+    const newPages = old?.pages.map((page) => ({
+      ...page,
+      contents: page.contents.map((content) =>
+        content.goal.goalId === goalId
+          ? {
+              ...content,
+              emojis: content.emojis.map((emoji) =>
+                emoji.id === emojiId
+                  ? { ...emoji, reactCount: emoji.reactCount + (isAddingEmoji ? 1 : -1), isMyReaction: isAddingEmoji }
+                  : emoji,
+              ),
+            }
+          : content,
+      ),
+    }));
+
+    return { ...old, pages: newPages };
+  };
+
+  return {
+    queryKey,
+    updateTimelineEmojiCount,
+  };
+};

--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -27,7 +27,7 @@ export const useCreateEmojiForFeed = () => {
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.post(`/goal/${goalId}/emoji/${emojiId}`),
     onMutate: async ({ goalId, emojiId }) => {
       const updater = (old: InfiniteData<GoalFeedResponse>) => {
-        if (!old) return old;
+        if (!old) return null;
 
         const reactEmojiData = queryClient
           .getQueryData<EmojisResponse>(['all-emoji'])

--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -2,6 +2,7 @@ import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
+import { useUpdateTimelineEmojiCount } from '@/features/home/hooks/useUpdateTimelineEmojiCount';
 
 import type { EmojisProps, GoalFeedResponse } from '../goal/useGetGoalFeeds';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
@@ -17,10 +18,14 @@ export const useCreateEmojiForFeed = () => {
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
   const targetQueryKey = ['goalFeeds'];
 
+  const { queryKey: timelineQueryKey, updateTimelineEmojiCount } = useUpdateTimelineEmojiCount({ isAddingEmoji: true });
+
   return useMutation({
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.post(`/goal/${goalId}/emoji/${emojiId}`),
     onMutate: async ({ goalId, emojiId }) => {
       const updater = (old: InfiniteData<GoalFeedResponse>) => {
+        if (!old) return old;
+
         const reactEmojiData = queryClient
           .getQueryData<EmojisResponse>(['all-emoji'])
           ?.find((emoji) => emoji.id === emojiId) as Emoji;
@@ -57,8 +62,11 @@ export const useCreateEmojiForFeed = () => {
       });
       return context;
     },
-    onSuccess: (_, { goalId }) => {
+    onSuccess: (_, { goalId, emojiId }) => {
       queryClient.invalidateQueries({ queryKey: ['emoji', goalId] });
+      // NOTE: + 버튼을 눌러서 이모지를 추가하는 경우에 낙관적 업데이트 불가능해서 논의 필요
+      queryClient.invalidateQueries({ queryKey: timelineQueryKey });
+      queryClient.setQueryData(timelineQueryKey, updateTimelineEmojiCount(goalId, emojiId));
     },
     onError: (_, __, context) => {
       queryClient.setQueryData(targetQueryKey, context?.previous);

--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -1,14 +1,11 @@
-import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
+import { useUpdateFeedEmojiCount } from '@/features/home/hooks/useUpdateFeedEmojiCount';
 import { useUpdateTimelineEmojiCount } from '@/features/home/hooks/useUpdateTimelineEmojiCount';
 import { useToast } from '@/hooks';
 
-import type { EmojisProps, GoalFeedResponse } from '../goal/useGetGoalFeeds';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
-
-import type { Emoji, EmojisResponse } from './useGetAllEmoji';
 
 type EmojiRequestParams = {
   goalId: number;
@@ -19,49 +16,16 @@ export const useCreateEmojiForFeed = () => {
   const toast = useToast();
 
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
-  const targetQueryKey = ['goalFeeds'];
 
+  const { queryKey: feedQueryKey, updateFeedEmojiCount } = useUpdateFeedEmojiCount({ isAddingEmoji: true });
   const { queryKey: timelineQueryKey, updateTimelineEmojiCount } = useUpdateTimelineEmojiCount({ isAddingEmoji: true });
 
   return useMutation({
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.post(`/goal/${goalId}/emoji/${emojiId}`),
     onMutate: async ({ goalId, emojiId }) => {
-      const updater = (old: InfiniteData<GoalFeedResponse>) => {
-        if (!old) return null;
-
-        const reactEmojiData = queryClient
-          .getQueryData<EmojisResponse>(['all-emoji'])
-          ?.find((emoji) => emoji.id === emojiId) as Emoji;
-
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            goals: page.goals.map((goal) =>
-              goal.goal.id === goalId
-                ? {
-                    ...goal,
-                    emojis: goal.emojis.find(({ id }) => id === emojiId)
-                      ? goal.emojis.map((emoji) =>
-                          emoji.id === emojiId
-                            ? { ...emoji, reactCount: emoji.reactCount + 1, isMyReaction: true }
-                            : emoji,
-                        )
-                      : [
-                          ...goal.emojis,
-                          { ...reactEmojiData, id: emojiId, reactCount: 1, isMyReaction: true } as EmojisProps,
-                        ],
-                    count: { ...goal.count, reaction: goal.count.reaction + 1 },
-                  }
-                : goal,
-            ),
-          })),
-        };
-      };
-
       const context = await optimisticUpdater({
-        queryKey: targetQueryKey,
-        updater,
+        queryKey: feedQueryKey,
+        updater: updateFeedEmojiCount(goalId, emojiId),
       });
       return context;
     },
@@ -73,7 +37,7 @@ export const useCreateEmojiForFeed = () => {
     },
     onError: (_, __, context) => {
       toast.warning('잠시후 다시 시도해주세요.');
-      queryClient.setQueryData(targetQueryKey, context?.previous);
+      queryClient.setQueryData(feedQueryKey, context?.previous);
     },
   });
 };

--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 import { useUpdateTimelineEmojiCount } from '@/features/home/hooks/useUpdateTimelineEmojiCount';
+import { useToast } from '@/hooks';
 
 import type { EmojisProps, GoalFeedResponse } from '../goal/useGetGoalFeeds';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
@@ -15,6 +16,8 @@ type EmojiRequestParams = {
 };
 
 export const useCreateEmojiForFeed = () => {
+  const toast = useToast();
+
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
   const targetQueryKey = ['goalFeeds'];
 
@@ -69,6 +72,7 @@ export const useCreateEmojiForFeed = () => {
       queryClient.setQueryData(timelineQueryKey, updateTimelineEmojiCount(goalId, emojiId));
     },
     onError: (_, __, context) => {
+      toast.warning('잠시후 다시 시도해주세요.');
       queryClient.setQueryData(targetQueryKey, context?.previous);
     },
   });

--- a/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
 import { useUpdateTimelineEmojiCount } from '@/features/home/hooks/useUpdateTimelineEmojiCount';
+import { useToast } from '@/hooks';
 
 import type { GoalFeedResponse } from '../goal/useGetGoalFeeds';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
@@ -13,6 +14,8 @@ type EmojiRequestParams = {
 };
 
 export const useDeleteReactedEmojiForFeed = () => {
+  const toast = useToast();
+
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
   const targetQueryKey = ['goalFeeds'];
 
@@ -60,6 +63,7 @@ export const useDeleteReactedEmojiForFeed = () => {
       queryClient.setQueryData(timelineQueryKey, updateTimelineEmojiCount(goalId, emojiId));
     },
     onError: (_, __, context) => {
+      toast.warning('잠시후 다시 시도해주세요.');
       queryClient.setQueryData(targetQueryKey, context?.previous);
     },
   });

--- a/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
@@ -27,7 +27,7 @@ export const useDeleteReactedEmojiForFeed = () => {
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.delete(`/goal/${goalId}/emoji/${emojiId}`),
     onMutate: async ({ goalId, emojiId }) => {
       const updater = (old: InfiniteData<GoalFeedResponse>) => {
-        if (!old) return old;
+        if (!old) return null;
 
         return {
           ...old,

--- a/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useDeleteReactedEmojiForFeed.ts
@@ -1,11 +1,10 @@
-import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 
 import { api } from '@/apis';
+import { useUpdateFeedEmojiCount } from '@/features/home/hooks/useUpdateFeedEmojiCount';
 import { useUpdateTimelineEmojiCount } from '@/features/home/hooks/useUpdateTimelineEmojiCount';
 import { useToast } from '@/hooks';
 
-import type { GoalFeedResponse } from '../goal/useGetGoalFeeds';
 import { useOptimisticUpdate } from '../useOptimisticUpdate';
 
 type EmojiRequestParams = {
@@ -17,8 +16,8 @@ export const useDeleteReactedEmojiForFeed = () => {
   const toast = useToast();
 
   const { queryClient, optimisticUpdater } = useOptimisticUpdate();
-  const targetQueryKey = ['goalFeeds'];
 
+  const { queryKey: feedQueryKey, updateFeedEmojiCount } = useUpdateFeedEmojiCount({ isAddingEmoji: false });
   const { queryKey: timelineQueryKey, updateTimelineEmojiCount } = useUpdateTimelineEmojiCount({
     isAddingEmoji: false,
   });
@@ -26,36 +25,11 @@ export const useDeleteReactedEmojiForFeed = () => {
   return useMutation({
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.delete(`/goal/${goalId}/emoji/${emojiId}`),
     onMutate: async ({ goalId, emojiId }) => {
-      const updater = (old: InfiniteData<GoalFeedResponse>) => {
-        if (!old) return null;
-
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            goals: page.goals.map((goal) =>
-              goal.goal.id === goalId
-                ? {
-                    ...goal,
-                    emojis: goal.emojis
-                      .map((emoji) =>
-                        emoji.id === emojiId
-                          ? { ...emoji, reactCount: emoji.reactCount - 1, isMyReaction: false }
-                          : emoji,
-                      )
-                      .filter(({ reactCount }) => reactCount > 0),
-                    count: { ...goal.count, reaction: goal.count.reaction - 1 },
-                  }
-                : goal,
-            ),
-          })),
-        };
-      };
-
       const context = await optimisticUpdater({
-        queryKey: targetQueryKey,
-        updater,
+        queryKey: feedQueryKey,
+        updater: updateFeedEmojiCount(goalId, emojiId),
       });
+
       return context;
     },
     onSuccess: (_, { goalId, emojiId }) => {
@@ -63,8 +37,8 @@ export const useDeleteReactedEmojiForFeed = () => {
       queryClient.setQueryData(timelineQueryKey, updateTimelineEmojiCount(goalId, emojiId));
     },
     onError: (_, __, context) => {
-      toast.warning('잠시후 다시 시도해주세요.');
-      queryClient.setQueryData(targetQueryKey, context?.previous);
+      toast.warning('이모지 삭제: 잠시후 다시 시도해주세요.');
+      queryClient.setQueryData(feedQueryKey, context?.previous);
     },
   });
 };

--- a/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
+++ b/src/hooks/reactQuery/goal/useGetGoalFeeds.ts
@@ -55,6 +55,7 @@ export const useGetGoalFeeds = () => {
     queryKey: ['goalFeeds'],
     queryFn: ({ pageParam }) => api.get<GoalFeedResponse>('/goal/explore', { params: { cursor: pageParam } }),
     initialPageParam: null,
-    getNextPageParam: ({ goals, cursor }) => (cursor && goals.length === PAGE_SIZE ? cursor.next : null),
+    getNextPageParam: (params) => (params?.cursor && params?.goals.length === PAGE_SIZE ? params?.cursor.next : null),
+    staleTime: 0,
   });
 };

--- a/src/hooks/reactQuery/goal/useGetTimeline.ts
+++ b/src/hooks/reactQuery/goal/useGetTimeline.ts
@@ -43,5 +43,6 @@ export const useGetTimeline = () => {
       }),
     initialPageParam: null,
     getNextPageParam: ({ isLast, nextCursor }) => (isLast ? null : nextCursor),
+    staleTime: 0,
   });
 };

--- a/src/hooks/reactQuery/useOptimisticUpdate.ts
+++ b/src/hooks/reactQuery/useOptimisticUpdate.ts
@@ -4,7 +4,13 @@ import { useQueryClient } from '@tanstack/react-query';
 export const useOptimisticUpdate = () => {
   const queryClient = useQueryClient();
 
-  const optimisticUpdater = async <T>({ queryKey, updater }: { queryKey: QueryKey; updater: (old: T) => T | null }) => {
+  const optimisticUpdater = async <T>({
+    queryKey,
+    updater,
+  }: {
+    queryKey: QueryKey;
+    updater: (old: T) => T | unknown;
+  }) => {
     await queryClient.cancelQueries({ queryKey });
     const previous = queryClient.getQueryData(queryKey);
 

--- a/src/hooks/reactQuery/useOptimisticUpdate.ts
+++ b/src/hooks/reactQuery/useOptimisticUpdate.ts
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 export const useOptimisticUpdate = () => {
   const queryClient = useQueryClient();
 
-  const optimisticUpdater = async <T>({ queryKey, updater }: { queryKey: QueryKey; updater: (old: T) => T }) => {
+  const optimisticUpdater = async <T>({ queryKey, updater }: { queryKey: QueryKey; updater: (old: T) => T | null }) => {
     await queryClient.cancelQueries({ queryKey });
     const previous = queryClient.getQueryData(queryKey);
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 타임라인 이모지 추가 / 삭제 안되는 이슈 수정

## 🎉 어떻게 해결했나요?
- 이모지 추가: 타임라인 api 호출
- 이모지 삭제: 낙관적 삭제

### 이모지 추가에서 타임라인을 호출하는 이유
- 이모지 추가 방식는 총 2가지
   - 1. 이모지를 눌러서 추가하는 방식 
   - 2. `+ 버튼` 눌러서 이모지 추가하는 방식

- 1번은 기존 이모지 배열에서 해당 emojiId의 count를 늘려주는 방식으로 낙관적 업데이트 가능
- 2번의 경우, 기존 이모지 배열에 없는 새로운 emojiId가 추가될 수 있음
   - 이모지 추가 시, 서버 응답으로 이모지 정보를 넘겨주고 있지 않아서 낙관적 업데이트 불가능

### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/80238096/4ebac255-da9e-4a53-8560-a1106f3531e4

- 이미 존재하는 이모지인데 `+버튼`을 눌러서 동일한 이모지를 누르는 경우, 서버 500에러 발생

