### PR TITLE
fix: 응원하기 버튼 클릭 후, 모든 버튼이 눌리지 않는 버그 수정

### DIFF
--- a/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
@@ -64,7 +64,7 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
 
   return (
     <>
-      {isSuccess && <CheeringClickedLottie />}
+      {isSuccess && lastCheerTime > 0 && <CheeringClickedLottie />}
       <div className="flex gap-5xs  px-xs pt-5xs mt-[18px] w-full z-[1]">
         <CheeringButton onClick={handleClickCheeringButton} />
         <Link href={{ pathname: myHomePath }} className="w-full">

--- a/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
+++ b/src/features/home/components/lifeMap/PublicLifeMapBottomArea.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useOverlay } from '@toss/use-overlay';
 
@@ -22,20 +22,19 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
   const { open } = useOverlay();
   const toast = useToast();
 
-  const [lastCheerTime, setLastCheerTime] = useState(0);
+  const lastCheerTime = useRef(0);
 
   // TODO: Lottie atom을 수정해서 로티 이미지를 플레이하는 방식으로 변경
   const { mutate: cheer, isSuccess } = useCreateCheering(username);
 
-  const CHEER_ANIMATION_INTERVAL = 5400;
   const CHEER_LIMIT_INTERVAL = 6000;
 
   useEffect(() => {
     if (!isSuccess) return;
 
     const timeoutId = setTimeout(() => {
-      setLastCheerTime(0);
-    }, CHEER_ANIMATION_INTERVAL);
+      lastCheerTime.current = 0;
+    }, CHEER_LIMIT_INTERVAL);
 
     return () => {
       clearTimeout(timeoutId);
@@ -53,18 +52,18 @@ const PublicLifeMapBottomArea = ({ username }: { username: string }) => {
     }
 
     const now = Date.now();
-    if (now - lastCheerTime < CHEER_LIMIT_INTERVAL && lastCheerTime !== 0) {
+    if (now - lastCheerTime.current < CHEER_LIMIT_INTERVAL && lastCheerTime.current !== 0) {
       toast.warning('1분 뒤에 응원할 수 있어요.');
       return;
     }
 
-    setLastCheerTime(now);
+    lastCheerTime.current = now;
     throttleCheer();
   };
 
   return (
     <>
-      {isSuccess && lastCheerTime > 0 && <CheeringClickedLottie />}
+      {isSuccess && lastCheerTime.current !== 0 && <CheeringClickedLottie />}
       <div className="flex gap-5xs  px-xs pt-5xs mt-[18px] w-full z-[1]">
         <CheeringButton onClick={handleClickCheeringButton} />
         <Link href={{ pathname: myHomePath }} className="w-full">

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -8,7 +8,6 @@ export const useThrottle = (callback: () => void, interval = 500) => {
       callback();
 
       timer.current = setTimeout(() => {
-        callback();
         timer.current = null;
       }, interval);
     }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [응원하기 버튼 클릭 후, 모든 버튼이 눌리지 않는 버그 수정](https://www.notion.so/depromeet/6f5b2e4a8ec74d2788cbb1ca7c197651?pvs=4)

## 🎉 어떻게 해결했나요?
- 원인: 응원하기 버튼 클릭 후, 응원에 성공한 경우에는 계속 로띠가 남아있음
- 수정: 응원하기 버튼 클릭 후에는 로띠가 보이지 않도록 조건 수정

### 📚 Attachment (Option)

