### PR TITLE
feat: composeEventHandlers 추가

### DIFF
--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -5,6 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { colors } from '@/../styles/theme';
 import SubmitIcon from '@/assets/icons/submit.svg';
+import { composeEventHandlers } from '@/utils/composeEventHandlers';
 
 const inputContainerVariants = cva(
   'p-3xs flex gap-6xs items-center w-full h-[56px] rounded-md bg-white border shadow-thumb',
@@ -31,7 +32,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement>,
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, includeSubmitButton = false, onSubmit = () => {}, ...props }: InputProps, ref) => {
+  ({ className, includeSubmitButton = false, onSubmit = () => {}, onFocus, onBlur, ...props }, ref) => {
     const [isFocused, setIsFocused] = useState(false);
 
     const handleFocus = useCallback(() => setIsFocused(true), []);
@@ -43,8 +44,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           className={inputVariants({ className })}
           ref={ref}
           {...props}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
+          onFocus={composeEventHandlers(onFocus, () => {
+            handleFocus();
+          })}
+          onBlur={composeEventHandlers(onBlur, () => {
+            handleBlur();
+          })}
         />
         {includeSubmitButton && (
           <div className="w-[32px] h-[32px]">

--- a/src/utils/composeEventHandlers.ts
+++ b/src/utils/composeEventHandlers.ts
@@ -1,0 +1,13 @@
+export const composeEventHandlers = <E>(
+  originalEventHandler?: (event: E) => void,
+  ourEventHandler?: (event: E) => void,
+  { checkForDefaultPrevented = true } = {},
+) => {
+  return function handleEvent(event: E) {
+    originalEventHandler?.(event);
+
+    if (checkForDefaultPrevented === false || !(event as unknown as Event).defaultPrevented) {
+      return ourEventHandler?.(event);
+    }
+  };
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- `<Input>` 컴포넌트를 보면 onFocus나 onBlur같은 이벤트 핸들러들에 대해 주입 받은 것들은 처리하지 않고 있었음

## 🎉 어떻게 해결했나요?
- `composeEventHandlers`를 추가해서 적용했어유 (참고: [radix-util](https://github.com/radix-ui/primitives/blob/main/packages/core/primitive/src/primitive.tsx))

```tsx
// Usage
onFocus={composeEventHandlers(onFocusFromProp, () => {
  // 내부에서 처리하고 있는 로직
})}
```

### 📚 Attachment (Option)
- N/A

