### PR TITLE
fix: 목표 수정 화면 날짜 수정 필드에 validation이 적용 안되는 이슈 해결

### DIFF
--- a/src/components/molecules/reactHookForm/RHFDateField.tsx
+++ b/src/components/molecules/reactHookForm/RHFDateField.tsx
@@ -42,7 +42,15 @@ const YearField = () => {
       control={control}
       rules={{ required: 'Year is required' }}
       render={({ field, fieldState: { error } }) => (
-        <Input {...field} type="number" id="year" placeholder="YYYY" aria-invalid={error ? 'true' : 'false'} />
+        <Input
+          {...field}
+          type="text"
+          inputMode="numeric"
+          maxLength={4}
+          id="year"
+          placeholder="YYYY"
+          aria-invalid={error ? 'true' : 'false'}
+        />
       )}
     />
   );
@@ -57,14 +65,22 @@ const MonthField = () => {
       control={control}
       rules={{ required: 'Month is required', min: 1, max: 12 }}
       render={({ field, fieldState: { error } }) => (
-        <Input {...field} type="number" id="month" placeholder="MM" aria-invalid={error ? 'true' : 'false'} />
+        <Input
+          {...field}
+          type="text"
+          inputMode="numeric"
+          maxLength={2}
+          id="month"
+          placeholder="MM"
+          aria-invalid={error ? 'true' : 'false'}
+        />
       )}
     />
   );
 };
 
 const DayField = () => {
-  const { control, watch, setValue, getValues } = useFormContext();
+  const { control, watch } = useFormContext();
   const year = watch('year');
   const month = watch('month');
 

--- a/src/features/goal/components/update/GoalUpdateForm.tsx
+++ b/src/features/goal/components/update/GoalUpdateForm.tsx
@@ -62,7 +62,7 @@ export const GoalUpdateForm = ({ goalId, goal }: GoalUpdateFormProps) => {
       }
 
       // validate deadline
-      if (isValidDate(data.year, data.month)) {
+      if (!isValidDate(data.year, data.month)) {
         toast.warning('유효한 날짜를 입력해 주세요.');
         return;
       }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -23,7 +23,7 @@ export const hasValidDateLengths = (year: string, month: string, day?: string) =
 export const doesDateExist = (year: string, month: string, day?: string) => {
   const yearNum = +year;
   const monthNum = +month - 1;
-  const dayNum = day ? +day : 0;
+  const dayNum = day ? +day : 1;
 
   const date = new Date(yearNum, monthNum, dayNum);
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 목표 수정 화면 날짜 수정 필드에 validation이 적용 안되는 이슈 해결

## 🎉 어떻게 해결했나요?
- number 타입에서 숫자 입력 시 maxLength 적용이 안되서 text 타입 + numeric inputMode로 변경
- maxLength 적용
- 반대로 적용된 isValidDate 수정
- date default값을 1로 수정 (0일 경우, 지난달 마지막 일로 변경됨..)

### 📚 Attachment (Option)
https://github.com/depromeet/amazing3-fe/assets/34956359/a3e2ef7e-37f6-425b-aa21-3430e5fb7c8e



