### PR TITLE
bug: commentBottomSheet 마운트 시 input focus 제거

### DIFF
--- a/src/features/comment/AddCommentInput.tsx
+++ b/src/features/comment/AddCommentInput.tsx
@@ -1,5 +1,5 @@
 import type { MutableRefObject } from 'react';
-import { forwardRef, useEffect } from 'react';
+import { forwardRef } from 'react';
 
 import { Input, type InputProps } from '@/components/atoms/input/Input';
 import { useInput } from '@/hooks';
@@ -24,8 +24,6 @@ export const AddCommentInput = forwardRef<HTMLInputElement, AddCommentInputProps
       handleFocusAction();
     };
 
-    useEffect(() => handleFocusAction(), []);
-
     return (
       <Input
         ref={ref}
@@ -35,6 +33,7 @@ export const AddCommentInput = forwardRef<HTMLInputElement, AddCommentInputProps
         maxLength={COMMENT_MAX_LENGTH}
         includeSubmitButton
         onSubmit={handleSubmit}
+        tabIndex={-1}
         {...props}
       />
     );


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [댓글 바텀시트 키패드 위치 의도대로 동작 X → 페이지뷰로 전환](https://www.notion.so/depromeet/X-88e0785d31f64a339aa340f939822024)

## 🎉 어떻게 해결했나요?
- 👆 위 노션 페이지에 재연 동영상 있는데
  - 모바일에서 맨 처음에 `focus가 되었음에도 키패드가 올라오지 않는 게` 제일 큰 애로사항이여서
  - 처음에 focus가 되지 않도록 하였고, focus되었을 때 viewport 조작할 수 있도록 수정해줬어유
  - 이거 반영되었는데도 사용감에 큰 불편함이 있다면 페이지뷰로 넘어가겠습니다...
- `😓 페이지뷰 한다면서..`
  - 댓글 바텀시트 사용처가 많아서 그런지 페이지뷰가 차암..아쉬워서 미련을 못 버린채 한번만 츄라이 해보았어요

### 📚 Attachment (Option)

https://github.com/depromeet/amazing3-fe/assets/112946860/247a6386-35a5-4ee8-a538-b3d8e9deb28c



