### PR TITLE
fix: 타임라인에서 새로고침 시 지도 페이지로 이동하는 이슈 수정

### DIFF
--- a/src/features/home/components/homeTab/HomeTab.tsx
+++ b/src/features/home/components/homeTab/HomeTab.tsx
@@ -1,5 +1,9 @@
 import type { Dispatch, FC, SetStateAction, SVGProps } from 'react';
 import { useState } from 'react';
+import type { Route } from 'next';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { useUpdateQueryString } from '@/hooks/useUpdateQueryString';
 
 import { HomeTabMenu } from './HomeTabMenu';
 
@@ -15,11 +19,23 @@ interface HomeTabProps {
 }
 
 export const HomeTab = ({ tabList, onChangeActiveTab }: HomeTabProps) => {
-  const [activeMenu, setActiveMenu] = useState<TabMenu>(tabList[0]);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const updateQueryString = useUpdateQueryString();
+
+  const currentTabName = searchParams.get('tab') ?? tabList[0].name;
+  const initialActiveTabIndex = tabList.findIndex((tab) => tab.name === currentTabName) || 0;
+
+  const [activeMenu, setActiveMenu] = useState<TabMenu>(tabList[initialActiveTabIndex]);
 
   const handleClickMenu = (tab: TabMenu) => () => {
     onChangeActiveTab(tab);
     setActiveMenu(tab);
+
+    const queryString = updateQueryString('tab', tab.name);
+    router.push(`${pathname}?${queryString}` as Route);
   };
 
   return (
@@ -39,7 +55,11 @@ export const HomeTab = ({ tabList, onChangeActiveTab }: HomeTabProps) => {
           );
         })}
 
-        <span className="absolute w-[24px] h-[24px] top-0 left-0 -z-10 origin-center rounded-sm bg-white transition-all duration-300 peer-checked/tab-1:left-[50%]"></span>
+        <span
+          className={`absolute w-[24px] h-[24px] top-0 left-0 -z-10 origin-center rounded-sm bg-white transition-all duration-300 peer-checked/tab-1:left-[50%] ${
+            initialActiveTabIndex === 0 ? 'left-0' : 'left-[50%]'
+          }`}
+        ></span>
       </div>
     </div>
   );

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
 
 import ActiveFeedMenuIcon from '@/assets/icons/home/feed-tab-active-icon.svg';
 import FeedMenuIcon from '@/assets/icons/home/feed-tab-default-icon.svg';
@@ -42,10 +43,13 @@ const TAB_LIST = [
 export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: LifeMapProps) => {
   const shareRef = useRef<HTMLElement>(null);
 
-  const [tab, setTab] = useState(TAB_LIST[0]);
+  const [, setTab] = useState(TAB_LIST[0]);
+  const searchParams = useSearchParams();
+
+  const tabName = searchParams.get('tab') ?? TAB_LIST[0].name;
 
   return (
-    <div className={`flex justify-center w-full ${tab.name === 'MAP' ? 'bg-gradient1' : 'bg-white'}`}>
+    <div className={`flex justify-center w-full ${tabName === 'MAP' ? 'bg-gradient1' : 'bg-white'}`}>
       <div className="w-[390px] relative pt-xs">
         <span className="absolute right-[24px]">
           {isPublic ? <Avatar size={40} profileImage={memberData?.image} /> : <ShareButton shareRef={shareRef} />}
@@ -78,9 +82,9 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
               <HomeTab tabList={TAB_LIST} onChangeActiveTab={setTab} />
             </div>
           </div>
-          {tab.name === 'MAP' && <StarBg />}
-          <div className={`h-[520px] overflow-auto ${tab.name === 'FEED' ? 'mt-[16px] border-t border-blue-10' : ''}`}>
-            {tab.name === 'MAP' ? <Map goalsData={goalsData} /> : <Timeline />}
+          {tabName === 'MAP' && <StarBg />}
+          <div className={`h-[520px] overflow-auto ${tabName === 'FEED' ? 'mt-[16px] border-t border-blue-10' : ''}`}>
+            {tabName === 'MAP' ? <Map goalsData={goalsData} /> : <Timeline />}
           </div>
         </ContentWrapper>
       </div>

--- a/src/hooks/useUpdateQueryString.ts
+++ b/src/hooks/useUpdateQueryString.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+export const useUpdateQueryString = () => {
+  const searchParams = useSearchParams();
+
+  return useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(name, value);
+
+      return params.toString();
+    },
+    [searchParams],
+  );
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [타임라인에서 새로고침 시 지도 페이지로 이동하는 이슈 수정](https://www.notion.so/depromeet/c35d7275f4e9449a8c82b677a4ed6592?pvs=4)

## 🎉 어떻게 해결했나요?

- 탭 상태를 `useState`에서 -> `쿼리스트링`으로 변경
    - AS-IS: 탭 상태를 `useState`로 관리하기 때문에 새로고침 시 탭의 초기 값인 지도 페이지로 변경됨
    - TO-BE: 탭 상태를 `쿼리스트링`으로 관리해서 새로고침 시에도 유지될 수 있도록 수정

### 📚 Attachment (Option)


https://github.com/depromeet/amazing3-fe/assets/80238096/1c6c0ff3-6d4b-4167-9051-e35c020c6577





