### PR TITLE
fix: 남의 지도 프로필 누르면 내 프로필로 이동하는 버그 수정

### DIFF
--- a/src/components/atoms/avatar/Avatar.tsx
+++ b/src/components/atoms/avatar/Avatar.tsx
@@ -11,7 +11,7 @@ export const Avatar = ({ size = 24, profileImage }: AvatarProps) => {
   return (
     <div
       style={{ width: size, height: size }}
-      className="flex justify-center items-center rounded-xl overflow-hidden bg-white cursor-pointer"
+      className="flex justify-center items-center rounded-xl overflow-hidden bg-white"
     >
       {!profileImage ? (
         <UserIcon width={`calc(${size} / 1.5)`} height={`calc(${size} / 1.5)`} />

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -2,7 +2,6 @@
 
 import { useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import Link from 'next/link';
 
 import ActiveFeedMenuIcon from '@/assets/icons/home/feed-tab-active-icon.svg';
 import FeedMenuIcon from '@/assets/icons/home/feed-tab-default-icon.svg';
@@ -49,13 +48,7 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
     <div className={`flex justify-center w-full ${tab.name === 'MAP' ? 'bg-gradient1' : 'bg-white'}`}>
       <div className="w-[390px] relative pt-xs">
         <span className="absolute right-[24px]">
-          {isPublic ? (
-            <Link href="/my" className="pointer-events-none">
-              <Avatar size={40} profileImage={memberData?.image} />
-            </Link>
-          ) : (
-            <ShareButton shareRef={shareRef} />
-          )}
+          {isPublic ? <Avatar size={40} profileImage={memberData?.image} /> : <ShareButton shareRef={shareRef} />}
         </span>
 
         <ContentWrapper


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [남의 지도 프로필 누르면 내 프로필로 이동하는 버그 수정](https://www.notion.so/depromeet/a610a98d8d294327ace67b0d0b46080f?pvs=4)

## 🎉 어떻게 해결했나요?
- 프로필에 링크 제거했습니다~
   - 아무래도 내 지도에서 프로필 -> 공유버튼으로 변경되면서 요상하게 변경된듯합니다
- 아바타 컴포넌트에 `cursor: pointer` 속성이 있어서 클릭 가능한 요소처럼 보여서 제거했습니다~
   - 아바타 컴포넌트를 링크나 버튼으로 사용하는 경우에는 한 번 래핑해서 사용하기 때문에 속성 삭제하는게 좋을듯합니다

### 📚 Attachment (Option)


https://github.com/depromeet/amazing3-fe/assets/80238096/e65b03b1-901b-4970-a0bf-549f5f31c248



