### PR TITLE
fix: goal detail 화면의 navigation이 비정상 동작하는 이슈 해결

### DIFF
--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import VerticalBarIcon from '@/assets/icons/vertical-bar.svg';
 import { Span, Typography } from '@/components';
@@ -15,9 +16,11 @@ interface FeedCardBodyProps {
 }
 
 export const FeedCardBody = ({ goal, count, footer }: FeedCardBodyProps) => {
+  const pathname = usePathname();
+
   return (
     <div className="ml-lg flex flex-col gap-4xs">
-      <Link href={{ pathname: `/goal/detail/${goal.id}` }}>
+      <Link href={{ pathname: `/goal/detail/${goal.id}`, query: { previous: pathname } }}>
         <div className="p-3xs flex flex-col gap-5xs bg-gray-10 rounded-lg">
           <div className="flex gap-5xs items-center">
             <Image

--- a/src/features/goal/components/detail/DetailHeader.tsx
+++ b/src/features/goal/components/detail/DetailHeader.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import type { Route } from 'next';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useOverlay } from '@toss/use-overlay';
 
 import EditIcon from '@/assets/icons/edit-icon.svg';
@@ -15,13 +17,29 @@ interface DetailHeaderProps {
 
 export const DetailHeader = ({ goalId }: DetailHeaderProps) => {
   const overlay = useOverlay();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { isMyMap, currentUsername } = useIsMyMap();
+
+  useEffect(() => {
+    const handleBackEvent = (event: PopStateEvent) => {
+      event.preventDefault();
+      const previousPath = searchParams.get('previous') as Route;
+      if (previousPath) {
+        router.push(`${previousPath}?id=${goalId}`);
+      } else {
+        router.push(`/home/${currentUsername}?id=${goalId}`);
+      }
+    };
+    window.addEventListener('popstate', handleBackEvent);
+    return () => {
+      window.removeEventListener('popstate', handleBackEvent);
+    };
+  }, [currentUsername, goalId, router, searchParams]);
 
   return (
     <>
-      <Link href={{ pathname: `/home/${currentUsername}`, query: { id: goalId } }}>
-        <CloseIcon />
-      </Link>
+      <CloseIcon onClick={() => router.back()} />
 
       {isMyMap && goalId && (
         <div className="flex space-x-4">

--- a/src/features/goal/components/update/GoalUpdateForm.tsx
+++ b/src/features/goal/components/update/GoalUpdateForm.tsx
@@ -89,7 +89,7 @@ export const GoalUpdateForm = ({ goalId, goal }: GoalUpdateFormProps) => {
         stickerId: sticker.id,
         description: data.description,
       });
-      router.push(`/goal/detail/${goalId}`);
+      router.back();
       reset();
     } catch (error) {
       console.error(error);

--- a/src/features/home/components/MapCardCollections/MapCard.tsx
+++ b/src/features/home/components/MapCardCollections/MapCard.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useOverlay } from '@toss/use-overlay';
 
 import { Typography } from '@/components';
@@ -18,12 +18,13 @@ export interface MapCardProps extends MapCardLayoutProps {
 export const MapCard = ({ goal, position }: MapCardProps) => {
   const { id, title, stickerUrl } = goal;
   const router = useRouter();
+  const pathname = usePathname();
   const { isLoggedIn } = useAuth();
   const { open } = useOverlay();
 
   const handleMapCardClick = () => {
     if (isLoggedIn) {
-      router.push(`/goal/detail/${id}`);
+      router.push(`/goal/detail/${id}?previous=${pathname}`);
     } else {
       open(({ isOpen, close }) => <LoginBottomSheet open={isOpen} onClose={close} />);
     }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- [Goal Page에서 뒤로 가기하면 지도 navigation이 첫 페이지로 가버림](https://www.notion.so/depromeet/Goal-Page-navigation-9fe3c08de2504280906f395b00436e89?pvs=4)
- [피드 → 세부목표 → 돌아가기 클릭 시 지도로 가버림](https://www.notion.so/depromeet/5f53ad00e7834fae9985da54d89f8312?pvs=4)

## 🎉 어떻게 해결했나요?
- goal detail 화면에 previous 경로와 popState 커스텀 동작 추가

### 📚 Attachment (Option)
https://github.com/depromeet/amazing3-fe/assets/34956359/56a0bc9a-7adf-46b0-a97c-7f10730b4433


