### PR TITLE
fix: 댓글 바텀시트 viewport 로직 제거

### DIFF
--- a/src/features/comment/BottomSheet/Layout.tsx
+++ b/src/features/comment/BottomSheet/Layout.tsx
@@ -1,10 +1,9 @@
-import { type PropsWithChildren, useEffect, useRef } from 'react';
+import { type PropsWithChildren, useRef } from 'react';
 import type { BottomSheetRef } from 'react-spring-bottom-sheet';
 import { useAtomValue } from 'jotai';
 
 import { BottomSheet } from '@/components';
 import type { BottomSheetProps } from '@/components/atoms/bottomSheet/BottomSheet';
-import { isIOS } from '@/utils/isIos';
 
 import { AddCommentInput } from '../AddCommentInput';
 
@@ -25,46 +24,15 @@ export const CommentBottomSheetLayout = ({
 }: PropsWithChildren<CommentBottomSheetLayoutProps>) => {
   const goalId = useAtomValue(goalIdAtom);
   const sheetRef = useRef<BottomSheetRef | null>(null);
-
-  const overlayRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleFocusInput = () => {
     sheetRef.current?.snapTo(({ maxHeight }) => maxHeight * 0.55);
-
-    /**
-     * NOTE
-     * IOS에서 Visual Viewport가 존재하여
-     * viewport가 아닌 document 자체를 키보드 높이 만큼 올려버림
-     * 참고 이미지:  https://velog.velcdn.com/images/gene028/post/acd8332c-9465-4b0e-94c9-469fe4e7056f/image.png
-     */
-    if (isIOS()) {
-      overlayRef.current = document.querySelector('[data-rsbs-overlay]') as HTMLDivElement;
-
-      overlayRef.current.style.bottom = '15px'; // 키패드 높이 만큼 올라감
-      overlayRef.current.style.height = '100%';
-      overlayRef.current.style.paddingBottom = '65%';
-    }
   };
 
-  const handleBlur = () => {
-    if (overlayRef.current) {
-      // Revert to the original state
-      overlayRef.current.style.bottom = '';
-      overlayRef.current.style.height = '';
-      overlayRef.current.style.paddingBottom = '';
-    }
+  const handleBlurInput = () => {
+    sheetRef.current?.snapTo(({ maxHeight }) => maxHeight * 0.99);
   };
-
-  useEffect(() => {
-    if (isIOS()) {
-      inputRef.current?.addEventListener('blur', handleBlur);
-
-      return () => {
-        inputRef.current?.removeEventListener('blur', handleBlur);
-      };
-    }
-  }, []);
 
   return (
     <BottomSheet
@@ -72,7 +40,9 @@ export const CommentBottomSheetLayout = ({
       ref={sheetRef}
       open={open}
       onDismiss={onClose}
-      FooterComponent={<AddCommentInput ref={inputRef} goalId={goalId} onFocus={handleFocusInput} />}
+      FooterComponent={
+        <AddCommentInput ref={inputRef} goalId={goalId} onFocus={handleFocusInput} onBlur={handleBlurInput} />
+      }
       defaultSnap={({ maxHeight }) => maxHeight * 0.55}
       snapPoints={({ maxHeight }) => [maxHeight * 0.55, maxHeight * 0.99]}
       {...props}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- dev에 머지되더니 정신을 못차리는 우리의 문제아 댓글 바텀시트 ^^ !

## 🎉 어떻게 해결했나요?
- 이젠 일부로 해줬던 viewport 로직 때문에 화면이 삐져나가고 있어서 이걸 제거해줬어요
- 그래서 바텀시트 height만 트릭 같이 조절하는 로직만 있어유

### 📚 Attachment (Option)

| AS-IS |  TO-BE |
|:--:|:--:|
| <video src="https://github.com/depromeet/amazing3-fe/assets/112946860/67dbb352-46f9-41a1-b9bd-d9f50c3b1377" /> | <video src="https://github.com/depromeet/amazing3-fe/assets/112946860/49fb8535-5359-479d-9466-2a28a887b9b3" /> |
| 분명 아까는 잘 됐는데 ;; 🚬 | 좀 애가 덩실거리긴 함 ㅋㅋ.. |

