### PR TITLE
fix: 남의 지도에서 로그인 유도 화면을 통해 로그인 시 마이 페이지로 이동하는 이슈 해결

### DIFF
--- a/src/app/oauth2/token/page.tsx
+++ b/src/app/oauth2/token/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import type { Route } from 'next';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useAuth } from '@/hooks';
@@ -21,7 +22,14 @@ const OAuthTokenPage = () => {
 
   useEffect(() => {
     if (isLoggedIn && memberData) {
-      router.push(isLoggedIn ? `/home/${memberData.username}` : '/onboarding');
+      const prevPath = sessionStorage.getItem('savedPathBeforeLogin') as Route;
+      if (prevPath?.startsWith('/') && prevPath !== '/') {
+        router.push(prevPath);
+        sessionStorage.removeItem('savedPathBeforeLogin');
+      } else {
+        router.push(isLoggedIn ? `/home/${memberData.username}` : '/onboarding');
+      }
+
       localStorage.setItem('username', memberData.username);
     }
   }, [memberData, router, isLoggedIn]);

--- a/src/components/molecules/loginIconSet/LoginIconSet.tsx
+++ b/src/components/molecules/loginIconSet/LoginIconSet.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import AppleIcon from '@/assets/icons/auth/apple.svg';
 import GoogleIcon from '@/assets/icons/auth/google.svg';
@@ -20,25 +21,31 @@ const loginPath = {
 };
 
 export const LoginIconSet = ({ google = false, naver = false, kakao = false, apple = false }: LoginIconSetProps) => {
+  const pathname = usePathname();
+
+  const handleLogin = () => {
+    sessionStorage.setItem('savedPathBeforeLogin', pathname);
+  };
+
   return (
     <div className="w-fit flex justify-between items-center gap-[24px]">
       {google && (
-        <Link href={{ pathname: loginPath.google }}>
+        <Link href={{ pathname: loginPath.google }} onClick={handleLogin}>
           <GoogleIcon />
         </Link>
       )}
       {naver && (
-        <Link href={{ pathname: loginPath.naver }}>
+        <Link href={{ pathname: loginPath.naver }} onClick={handleLogin}>
           <NaverIcon />
         </Link>
       )}
       {kakao && (
-        <Link href={{ pathname: loginPath.kakao }}>
+        <Link href={{ pathname: loginPath.kakao }} onClick={handleLogin}>
           <KakaoIcon />
         </Link>
       )}
       {apple && (
-        <Link href={{ pathname: loginPath.apple }}>
+        <Link href={{ pathname: loginPath.apple }} onClick={handleLogin}>
           <AppleIcon />
         </Link>
       )}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 남의 지도에서 로그인 유도 화면을 통해 로그인 시 마이 페이지로 이동하는 이슈 해결

## 🎉 어떻게 해결했나요?
- login 페이지 이동 전에 현재 페이지 path를 저장하고 로그인 성공 시 redirect 수행

### 📚 Attachment (Option)
- localhost에서는 로그인 안했을 때 home 페이지로 접근하면 서버에서 500 던지네요;; 일단 코드에서 현재 경로 수정해서 테스트 했습니다. dev로 반영 후 다시 확인해 보겠습니다~

https://github.com/depromeet/amazing3-fe/assets/34956359/08781802-b0e0-4a47-9661-e0cacaf5b865


