### PR TITLE
fix: 남의 목표에서 삭제/수정 버튼이 생기는 이슈 해결 (+ 수정 기능 뒤로가기 경로 수정)

### DIFF
--- a/src/features/feed/feedCard/FeedCard.tsx
+++ b/src/features/feed/feedCard/FeedCard.tsx
@@ -31,6 +31,7 @@ const FeedCard = ({ feedData }: FeedCardProps) => {
               key={goal.id}
               goal={goal}
               count={count}
+              username={user.username}
               footer={
                 <>
                   <ReactionGroup targetGoalId={goal.id} reactedEmojis={emojis} />

--- a/src/features/feed/feedCard/FeedCardBody.tsx
+++ b/src/features/feed/feedCard/FeedCardBody.tsx
@@ -6,21 +6,27 @@ import { usePathname } from 'next/navigation';
 import VerticalBarIcon from '@/assets/icons/vertical-bar.svg';
 import { Span, Typography } from '@/components';
 import { blueDataURL } from '@/constants';
+import { CURRENT_LIFEMAP_USERNAME_KEY } from '@/constants/storageKey';
 import type { CountProps, GoalProps } from '@/hooks/reactQuery/goal/useGetGoalFeeds';
 import { formatDotYYYYMM } from '@/utils/date';
 
 interface FeedCardBodyProps {
   goal: GoalProps;
   count: CountProps;
+  username: string;
   footer?: ReactNode;
 }
 
-export const FeedCardBody = ({ goal, count, footer }: FeedCardBodyProps) => {
+export const FeedCardBody = ({ goal, count, username, footer }: FeedCardBodyProps) => {
   const pathname = usePathname();
+
+  const handleClickFeedCard = () => {
+    localStorage.setItem(CURRENT_LIFEMAP_USERNAME_KEY, username);
+  };
 
   return (
     <div className="ml-lg flex flex-col gap-4xs">
-      <Link href={{ pathname: `/goal/detail/${goal.id}`, query: { previous: pathname } }}>
+      <Link onClick={handleClickFeedCard} href={{ pathname: `/goal/detail/${goal.id}`, query: { previous: pathname } }}>
         <div className="p-3xs flex flex-col gap-5xs bg-gray-10 rounded-lg">
           <div className="flex gap-5xs items-center">
             <Image

--- a/src/features/goal/components/detail/DetailHeader.tsx
+++ b/src/features/goal/components/detail/DetailHeader.tsx
@@ -39,7 +39,9 @@ export const DetailHeader = ({ goalId }: DetailHeaderProps) => {
 
   return (
     <>
-      <CloseIcon onClick={() => router.back()} />
+      <button onClick={() => router.back()} type="button">
+        <CloseIcon />
+      </button>
 
       {isMyMap && goalId && (
         <div className="flex space-x-4">

--- a/src/features/goal/components/update/GoalUpdateForm.tsx
+++ b/src/features/goal/components/update/GoalUpdateForm.tsx
@@ -100,7 +100,7 @@ export const GoalUpdateForm = ({ goalId, goal }: GoalUpdateFormProps) => {
     <FormProvider {...methods}>
       <form onSubmit={onSubmit}>
         <FormLayout
-          header={<GoalUpdateHeader goalId={goalId} />}
+          header={<GoalUpdateHeader />}
           body={
             <div className="py-sm flex flex-col space-y-sm">
               <RHFTextField name="title" label="한줄목표" maxLength={30} />

--- a/src/features/goal/components/update/GoalUpdateHeader.tsx
+++ b/src/features/goal/components/update/GoalUpdateHeader.tsx
@@ -1,19 +1,17 @@
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import BackIcon from '@/assets/icons/goal/back-icon.svg';
 import { Typography } from '@/components/atoms';
 
-interface GoalUpdateHeaderProps {
-  goalId: number;
-}
-
 // TODO: 응원 페이지, 내 정보 수정 페이지와 중복됨. 공통 컴포넌트로 분리 필요.
-const GoalUpdateHeader = ({ goalId }: GoalUpdateHeaderProps) => {
+const GoalUpdateHeader = () => {
+  const router = useRouter();
+
   return (
     <div className="flex justify-between items-center">
-      <Link href={{ pathname: `/goal/detail/${goalId}` }}>
+      <button onClick={() => router.back()} type="button">
         <BackIcon />
-      </Link>
+      </button>
       <Typography type="title1" className="text-gray-60">
         목표 수정
       </Typography>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- Feed를 통해 들어간 다른 사람의 목표에서 삭제/수정 버튼이 생김.
- 수정 기능 화면에서 뒤로 가기 클릭 -> 목표에서 뒤로가기 클릭 -> 항상 지도 화면으로 돌아감.

## 🎉 어떻게 해결했나요?
- detail 경로에 들어갈 때 목표의 currentUser 값 변경
- 뒤로가기 기능 경로 수정

### 📚 Attachment (Option)
https://github.com/depromeet/amazing3-fe/assets/34956359/85a479d6-3703-48e7-9372-6aef3bfa3659


