### PR TITLE
fix: 피드에서 +버튼으로 이모지 추가 시, 계속 이모지 개수가 늘어나는 버그 수정

### DIFF
--- a/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
+++ b/src/hooks/reactQuery/emoji/useCreateEmojiForFeed.ts
@@ -1,11 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/apis';
-import { useUpdateFeedEmojiCount } from '@/features/home/hooks/useUpdateFeedEmojiCount';
 import { useUpdateTimelineEmojiCount } from '@/features/home/hooks/useUpdateTimelineEmojiCount';
 import { useToast } from '@/hooks';
-
-import { useOptimisticUpdate } from '../useOptimisticUpdate';
 
 type EmojiRequestParams = {
   goalId: number;
@@ -15,29 +12,21 @@ type EmojiRequestParams = {
 export const useCreateEmojiForFeed = () => {
   const toast = useToast();
 
-  const { queryClient, optimisticUpdater } = useOptimisticUpdate();
+  const queryClient = useQueryClient();
 
-  const { queryKey: feedQueryKey, updateFeedEmojiCount } = useUpdateFeedEmojiCount({ isAddingEmoji: true });
   const { queryKey: timelineQueryKey, updateTimelineEmojiCount } = useUpdateTimelineEmojiCount({ isAddingEmoji: true });
 
   return useMutation({
     mutationFn: ({ goalId, emojiId }: EmojiRequestParams) => api.post(`/goal/${goalId}/emoji/${emojiId}`),
-    onMutate: async ({ goalId, emojiId }) => {
-      const context = await optimisticUpdater({
-        queryKey: feedQueryKey,
-        updater: updateFeedEmojiCount(goalId, emojiId),
-      });
-      return context;
-    },
     onSuccess: (_, { goalId, emojiId }) => {
       queryClient.invalidateQueries({ queryKey: ['emoji', goalId] });
+      queryClient.invalidateQueries({ queryKey: ['goalFeeds', goalId] });
       // NOTE: + 버튼을 눌러서 이모지를 추가하는 경우에 낙관적 업데이트 불가능해서 논의 필요
       queryClient.invalidateQueries({ queryKey: timelineQueryKey });
       queryClient.setQueryData(timelineQueryKey, updateTimelineEmojiCount(goalId, emojiId));
     },
-    onError: (_, __, context) => {
+    onError: () => {
       toast.warning('잠시후 다시 시도해주세요.');
-      queryClient.setQueryData(feedQueryKey, context?.previous);
     },
   });
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 피드 > +버튼 > 이모지 추가 시, 계속 이모지 개수가 늘어나는 버그 수정

## 🎉 어떻게 해결했나요?
- 피드 > +버튼 > 이모지 추가 시, 낙관적 업데이트 제거

### 📚 Attachment (Option)
- 이거 원래 + 버튼 클릭해서 이모지 추가하는 경우, 기존에 해당 이모지를 클릭한 경우 제거되는 정책 아니였어?
    > - 1. 1번 이모지를 이미 눌러놓은 상태
    > - 2. +버튼을 이용해서 1번 이미지 또 클릭
    > - 3. `1번 이모지 삭제`? or `그대로 유지`?
 
- 현재는 `그대로 유지`로 작동함 -> 피드 / 타임라인 / 세부목표 모두 동일
