### PR TITLE
fix: 모바일뷰에서 양쪽 여백이 없어 답답해 보이는 문제 해결

### DIFF
--- a/src/components/molecules/contentWrapper/ContentWrapper.tsx
+++ b/src/components/molecules/contentWrapper/ContentWrapper.tsx
@@ -13,7 +13,7 @@ interface ContentWrapperProps {
 export const ContentWrapper = forwardRef<HTMLElement, PropsWithChildren<ContentWrapperProps>>(
   ({ title, description, sectionStyles = '', children }, ref) => {
     return (
-      <section className={sectionStyles} ref={ref}>
+      <section className={`${sectionStyles} px-xs`} ref={ref}>
         <Typography type="heading2" className="text-blue-50">
           {title}
         </Typography>

--- a/src/features/home/components/lifeMap/LifeMapContent.tsx
+++ b/src/features/home/components/lifeMap/LifeMapContent.tsx
@@ -78,7 +78,7 @@ export const LifeMapContent = ({ goalsData, memberData, isPublic = false }: Life
         >
           <div className="flex h-[24px] items-center mt-5xs">
             <LifeMapInfo goalsData={goalsData} />
-            <div className="absolute right-0">
+            <div className="absolute mr-xs right-0">
               <HomeTab tabList={TAB_LIST} onChangeActiveTab={setTab} />
             </div>
           </div>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- 양쪽 여백이 없어 답답하게 느껴졌어유

## 🎉 어떻게 해결했나요?

| AS-IS | TO-BE |
|:--:|:--:|
| ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/0403cf12-2d93-4f2b-a146-c09a99d4f19f) | ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/2584d049-e123-4cb4-a895-84b2688d5f46) |


### 📚 Attachment (Option)
- N/A

