### PR TITLE
hotfix: initialPageParam에 null 대신 0을 입력

### DIFF
--- a/src/hooks/reactQuery/goal/useGetPublicTimeline.ts
+++ b/src/hooks/reactQuery/goal/useGetPublicTimeline.ts
@@ -13,7 +13,7 @@ export const useGetPublicTimeline = (username: string) => {
       api.get<TimelineResponse>(`/open/life-map/timeline/${username}`, {
         params: { page: pageParam, size: PAGE_SIZE },
       }),
-    initialPageParam: null,
+    initialPageParam: 0,
     getNextPageParam: ({ total, page: currentPage }) => {
       const isLast = (currentPage + 1) * PAGE_SIZE >= total;
       const nextPage = currentPage + 1;

--- a/src/hooks/reactQuery/goal/useGetTimeline.ts
+++ b/src/hooks/reactQuery/goal/useGetTimeline.ts
@@ -41,7 +41,7 @@ export const useGetTimeline = () => {
       api.get<TimelineResponse>(`/life-map/timeline`, {
         params: { page: pageParam, size: PAGE_SIZE },
       }),
-    initialPageParam: null,
+    initialPageParam: 0,
     getNextPageParam: ({ total, page: currentPage }) => {
       const isLast = (currentPage + 1) * PAGE_SIZE >= total;
       const nextPage = currentPage + 1;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- page 값에 NaN가 전달되는 이슈 발견


## 🎉 어떻게 해결했나요?
- initialPageParam에 null 대신 0 입력

### 📚 Attachment (Option)
정상 동작 확인 (근데 dev 환경에서 frontend는 null이든 0이든 똑같이 동작해서 서버나 DB 문제일 듯..?)

