### PR TITLE
fix: 이모지 바텀시트에서 프로필 이미지가 길어지는 문제 해결

### DIFF
--- a/src/components/atoms/avatar/Avatar.tsx
+++ b/src/components/atoms/avatar/Avatar.tsx
@@ -1,5 +1,4 @@
 import type { SyntheticEvent } from 'react';
-import Link from 'next/link';
 
 import UserIcon from '@/assets/icons/user.svg';
 import DefaultProfileImage from '@/assets/images/default-profile.png';
@@ -7,27 +6,24 @@ import DefaultProfileImage from '@/assets/images/default-profile.png';
 interface AvatarProps {
   size?: number;
   profileImage?: string;
-  href?: string;
 }
 
-export const Avatar = ({ size = 24, profileImage, href }: AvatarProps) => {
+export const Avatar = ({ size = 24, profileImage }: AvatarProps) => {
   const handleAddDefaultImg = (e: SyntheticEvent<HTMLImageElement, Event>) => {
     e.currentTarget.src = DefaultProfileImage.src;
   };
 
   return (
-    <Link href={{ pathname: href }}>
-      <div
-        style={{ width: size, height: size }}
-        className="flex justify-center items-center rounded-xl overflow-hidden bg-white"
-      >
-        {!profileImage ? (
-          <UserIcon width={`calc(${size} / 1.5)`} height={`calc(${size} / 1.5)`} />
-        ) : (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={profileImage} width={size} height={size} alt="profile_image" onError={handleAddDefaultImg} />
-        )}
-      </div>
-    </Link>
+    <div
+      style={{ width: size, height: size }}
+      className="flex justify-center items-center rounded-xl overflow-hidden bg-white"
+    >
+      {!profileImage ? (
+        <UserIcon width={`calc(${size} / 1.5)`} height={`calc(${size} / 1.5)`} />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={profileImage} width={size} height={size} alt="profile_image" onError={handleAddDefaultImg} />
+      )}
+    </div>
   );
 };

--- a/src/components/molecules/comment/Comment.tsx
+++ b/src/components/molecules/comment/Comment.tsx
@@ -22,7 +22,7 @@ interface CommentProps {
 export const Comment = ({ commenter, content, writtenAt, isDeletable, onDelete }: CommentProps) => {
   return (
     <m.div className="flex gap-4xs" {...animate}>
-      <Avatar profileImage={commenter.image} size={50} href={`/home/${commenter.username}`} />
+      <Avatar profileImage={commenter.image} size={50} />
       <div className="w-full flex flex-col justify-between">
         <div className="w-full flex justify-between">
           <div className="flex gap-6xs items-center">

--- a/src/features/emoji/BottomSheet/ReactUser.tsx
+++ b/src/features/emoji/BottomSheet/ReactUser.tsx
@@ -1,7 +1,6 @@
-import Image from 'next/image';
 import Link from 'next/link';
 
-import { Typography } from '@/components';
+import { Avatar, Typography } from '@/components';
 
 import type { ReactedUserProps } from './Content';
 
@@ -10,7 +9,7 @@ export const ReactUser = ({ username, image, nickname }: ReactedUserProps) => {
     <Link href={{ pathname: `/home/${username}` }}>
       <button className="w-full flex flex-col gap-xs">
         <div className="flex gap-4xs items-center">
-          <Image src={image} width={50} height={50} alt="user-profile" className="rounded-full" />
+          <Avatar profileImage={image} size={50} />
           <Typography type="body1">{nickname}</Typography>
         </div>
       </button>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- https://github.com/depromeet/amazing3-fe/issues/278
- https://github.com/depromeet/amazing3-fe/issues/280

## 🎉 어떻게 해결했나요?
- `Avatar` 컴포넌트 사용
- `Avatar`에서 href 제거
  - 이유: 프로필 이미지에서만 href를 사용하는 경우보다는 nickname과 감싼 div에서 Link를 주는 경우가 더 많을 것 같아 제거했어용

### 📚 Attachment (Option)
close #278
close #280

