### PR TITLE
fix: 빠진 value prop 추가

### DIFF
--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -49,6 +49,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         <input
           className={inputVariants({ className })}
           ref={ref}
+          value={value}
           {...props}
           onFocus={composeEventHandlers(onFocus, () => {
             handleFocus();

--- a/src/features/goal/components/new/DateInput.tsx
+++ b/src/features/goal/components/new/DateInput.tsx
@@ -23,7 +23,7 @@ export const DateInput = ({
   const { inputRefs, dateValues, handleInputChange, handleInputBlur } = useDateInput({ initialValue });
 
   useEffect(() => {
-    onChange && onChange(formatDate(requireDateType.map((type) => dateValues[type])));
+    onChange?.(formatDate(requireDateType.map((type) => dateValues[type])));
   }, [dateValues, onChange, requireDateType]);
 
   return (


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - [간략한 task 설명](task 관련 링크) -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<!-- # Attachment (Option) -->
<!-- - 노션에 사용자를 위한 기능 가이드 (링크) -->

## 🤔 해결하려는 문제가 무엇인가요?
- https://github.com/depromeet/amazing3-fe/issues/285

## 🎉 어떻게 해결했나요?

| AS-IS | TO-BE |
|:--:|:--:|
| ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/77f7e2f4-90b3-408a-8da9-f611eb737db7) |  ![image](https://github.com/depromeet/amazing3-fe/assets/112946860/dfca5d23-1415-4ac4-8557-9fea7cf08d8f) |


### 📚 Attachment (Option)
- ㅋㅋㅋㅋ 이거 없어서 인풋류 초기값 다 문제 있었을텐데 아무도 몰랐던게 개콘이다~

close #285 

